### PR TITLE
chore: update aidoku-rs

### DIFF
--- a/sources/en.mangabat/Cargo.lock
+++ b/sources/en.mangabat/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "aidoku"
 version = "0.3.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git?branch=next#2e2d4c7f978b02363f38775b5955a35fe94a598b"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#d922d82068d18b0c115a2185a86cbc3e849e739b"
 dependencies = [
  "chrono",
  "euclid",
@@ -32,7 +32,7 @@ dependencies = [
 [[package]]
 name = "aidoku-test"
 version = "1.0.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git?branch=next#2e2d4c7f978b02363f38775b5955a35fe94a598b"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#d922d82068d18b0c115a2185a86cbc3e849e739b"
 dependencies = [
  "quote",
  "syn",
@@ -82,9 +82,12 @@ dependencies = [
 
 [[package]]
 name = "cobs"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "critical-section"
@@ -211,9 +214,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "postcard"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
+checksum = "6c1de96e20f51df24ca73cafcc4690e044854d803259db27a00a461cb3b9d17a"
 dependencies = [
  "cobs",
  "embedded-io 0.4.0",
@@ -332,6 +335,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3ae828aa394de34c7de08f522d1b86bd1c182c668d27da69caadda00590f26d"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/sources/en.mangabat/Cargo.toml
+++ b/sources/en.mangabat/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next", version = "0.3.0" }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", version = "0.3.0" }
 mangabox = { path = "../../templates/mangabox" }
 
 [dev-dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next", features = ["test"] }
-aidoku-test = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next" }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", features = ["test"] }
+aidoku-test = { git = "https://github.com/Aidoku/aidoku-rs.git" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/sources/en.mangabat/src/lib.rs
+++ b/sources/en.mangabat/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use aidoku::{prelude::*, DeepLinkHandler, Home, ImageRequestProvider, ListingProvider, Source};
+use aidoku::{prelude::*, Source};
 use mangabox::{Impl, MangaBox, Params};
 
 const BASE_URL: &str = "https://www.mangabats.com";

--- a/sources/en.mangakakalot/Cargo.lock
+++ b/sources/en.mangakakalot/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "aidoku"
 version = "0.3.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git?branch=next#2e2d4c7f978b02363f38775b5955a35fe94a598b"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#d922d82068d18b0c115a2185a86cbc3e849e739b"
 dependencies = [
  "chrono",
  "euclid",
@@ -32,7 +32,7 @@ dependencies = [
 [[package]]
 name = "aidoku-test"
 version = "1.0.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git?branch=next#2e2d4c7f978b02363f38775b5955a35fe94a598b"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#d922d82068d18b0c115a2185a86cbc3e849e739b"
 dependencies = [
  "quote",
  "syn",
@@ -82,9 +82,12 @@ dependencies = [
 
 [[package]]
 name = "cobs"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "critical-section"
@@ -211,9 +214,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "postcard"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
+checksum = "6c1de96e20f51df24ca73cafcc4690e044854d803259db27a00a461cb3b9d17a"
 dependencies = [
  "cobs",
  "embedded-io 0.4.0",
@@ -332,6 +335,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3ae828aa394de34c7de08f522d1b86bd1c182c668d27da69caadda00590f26d"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/sources/en.mangakakalot/Cargo.toml
+++ b/sources/en.mangakakalot/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next", version = "0.3.0" }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", version = "0.3.0" }
 mangabox = { path = "../../templates/mangabox" }
 
 [dev-dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next", features = ["test"] }
-aidoku-test = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next" }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", features = ["test"] }
+aidoku-test = { git = "https://github.com/Aidoku/aidoku-rs.git" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/sources/en.mangakakalot/src/lib.rs
+++ b/sources/en.mangakakalot/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use aidoku::{prelude::*, DeepLinkHandler, Home, ImageRequestProvider, ListingProvider, Source};
+use aidoku::{prelude::*, Source};
 use mangabox::{Impl, MangaBox, Params};
 
 const BASE_URL: &str = "https://www.mangakakalot.gg";

--- a/sources/en.manganato/Cargo.lock
+++ b/sources/en.manganato/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "aidoku"
 version = "0.3.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git?branch=next#2e2d4c7f978b02363f38775b5955a35fe94a598b"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#d922d82068d18b0c115a2185a86cbc3e849e739b"
 dependencies = [
  "chrono",
  "euclid",
@@ -32,7 +32,7 @@ dependencies = [
 [[package]]
 name = "aidoku-test"
 version = "1.0.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git?branch=next#2e2d4c7f978b02363f38775b5955a35fe94a598b"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#d922d82068d18b0c115a2185a86cbc3e849e739b"
 dependencies = [
  "quote",
  "syn",
@@ -82,9 +82,12 @@ dependencies = [
 
 [[package]]
 name = "cobs"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "critical-section"
@@ -211,9 +214,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "postcard"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
+checksum = "6c1de96e20f51df24ca73cafcc4690e044854d803259db27a00a461cb3b9d17a"
 dependencies = [
  "cobs",
  "embedded-io 0.4.0",
@@ -332,6 +335,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3ae828aa394de34c7de08f522d1b86bd1c182c668d27da69caadda00590f26d"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/sources/en.manganato/Cargo.toml
+++ b/sources/en.manganato/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next", version = "0.3.0" }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", version = "0.3.0" }
 mangabox = { path = "../../templates/mangabox" }
 
 [dev-dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next", features = ["test"] }
-aidoku-test = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next" }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", features = ["test"] }
+aidoku-test = { git = "https://github.com/Aidoku/aidoku-rs.git" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/sources/en.manganato/src/lib.rs
+++ b/sources/en.manganato/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use aidoku::{prelude::*, DeepLinkHandler, Home, ImageRequestProvider, ListingProvider, Source};
+use aidoku::{prelude::*, Source};
 use mangabox::{Impl, MangaBox, Params};
 
 const BASE_URL: &str = "https://www.manganato.gg";

--- a/sources/en.manganelo/Cargo.lock
+++ b/sources/en.manganelo/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "aidoku"
 version = "0.3.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git?branch=next#2e2d4c7f978b02363f38775b5955a35fe94a598b"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#d922d82068d18b0c115a2185a86cbc3e849e739b"
 dependencies = [
  "chrono",
  "euclid",
@@ -32,7 +32,7 @@ dependencies = [
 [[package]]
 name = "aidoku-test"
 version = "1.0.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git?branch=next#2e2d4c7f978b02363f38775b5955a35fe94a598b"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#d922d82068d18b0c115a2185a86cbc3e849e739b"
 dependencies = [
  "quote",
  "syn",
@@ -82,9 +82,12 @@ dependencies = [
 
 [[package]]
 name = "cobs"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "critical-section"
@@ -211,9 +214,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "postcard"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
+checksum = "6c1de96e20f51df24ca73cafcc4690e044854d803259db27a00a461cb3b9d17a"
 dependencies = [
  "cobs",
  "embedded-io 0.4.0",
@@ -332,6 +335,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3ae828aa394de34c7de08f522d1b86bd1c182c668d27da69caadda00590f26d"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/sources/en.manganelo/Cargo.toml
+++ b/sources/en.manganelo/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next", version = "0.3.0" }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", version = "0.3.0" }
 mangabox = { path = "../../templates/mangabox" }
 
 [dev-dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next", features = ["test"] }
-aidoku-test = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next" }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", features = ["test"] }
+aidoku-test = { git = "https://github.com/Aidoku/aidoku-rs.git" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/sources/en.manganelo/src/lib.rs
+++ b/sources/en.manganelo/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use aidoku::{prelude::*, DeepLinkHandler, Home, ImageRequestProvider, ListingProvider, Source};
+use aidoku::{prelude::*, Source};
 use mangabox::{Impl, MangaBox, Params};
 
 const BASE_URL: &str = "https://www.nelomanga.net";

--- a/sources/en.weebcentral/Cargo.lock
+++ b/sources/en.weebcentral/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "aidoku"
 version = "0.3.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git?branch=next#2e2d4c7f978b02363f38775b5955a35fe94a598b"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#d922d82068d18b0c115a2185a86cbc3e849e739b"
 dependencies = [
  "chrono",
  "euclid",
@@ -31,7 +31,7 @@ dependencies = [
 [[package]]
 name = "aidoku-test"
 version = "1.0.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git?branch=next#2e2d4c7f978b02363f38775b5955a35fe94a598b"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#d922d82068d18b0c115a2185a86cbc3e849e739b"
 dependencies = [
  "quote",
  "syn",
@@ -81,9 +81,12 @@ dependencies = [
 
 [[package]]
 name = "cobs"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "critical-section"
@@ -180,9 +183,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "postcard"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
+checksum = "6c1de96e20f51df24ca73cafcc4690e044854d803259db27a00a461cb3b9d17a"
 dependencies = [
  "cobs",
  "embedded-io 0.4.0",
@@ -283,6 +286,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3ae828aa394de34c7de08f522d1b86bd1c182c668d27da69caadda00590f26d"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/sources/en.weebcentral/Cargo.toml
+++ b/sources/en.weebcentral/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next", version = "0.3.0" }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", version = "0.3.0" }
 chrono = { version = "0.4.30", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next", features = ["test"] }
-aidoku-test = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next" }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", features = ["test"] }
+aidoku-test = { git = "https://github.com/Aidoku/aidoku-rs.git" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/sources/ja.comicdays/Cargo.lock
+++ b/sources/ja.comicdays/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "aidoku"
 version = "0.3.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git?branch=next#2e2d4c7f978b02363f38775b5955a35fe94a598b"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#d922d82068d18b0c115a2185a86cbc3e849e739b"
 dependencies = [
  "chrono",
  "euclid",
@@ -32,7 +32,7 @@ dependencies = [
 [[package]]
 name = "aidoku-test"
 version = "1.0.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git?branch=next#2e2d4c7f978b02363f38775b5955a35fe94a598b"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#d922d82068d18b0c115a2185a86cbc3e849e739b"
 dependencies = [
  "quote",
  "syn",
@@ -82,9 +82,12 @@ dependencies = [
 
 [[package]]
 name = "cobs"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "comicdays"
@@ -211,9 +214,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "postcard"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
+checksum = "6c1de96e20f51df24ca73cafcc4690e044854d803259db27a00a461cb3b9d17a"
 dependencies = [
  "cobs",
  "embedded-io 0.4.0",
@@ -316,9 +319,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -332,6 +335,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3ae828aa394de34c7de08f522d1b86bd1c182c668d27da69caadda00590f26d"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/sources/ja.comicdays/Cargo.toml
+++ b/sources/ja.comicdays/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next", version = "0.3.0" }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", version = "0.3.0" }
 gigaviewer = { path = "../../templates/gigaviewer" }
 
 [dev-dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next", features = ["test"] }
-aidoku-test = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next" }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", features = ["test"] }
+aidoku-test = { git = "https://github.com/Aidoku/aidoku-rs.git" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/sources/ja.comicdays/src/lib.rs
+++ b/sources/ja.comicdays/src/lib.rs
@@ -3,8 +3,8 @@ use aidoku::{
 	alloc::{vec, String, Vec},
 	imports::{html::Document, net::Request},
 	prelude::*,
-	BasicLoginHandler, DeepLinkHandler, Home, HomeComponent, HomeLayout, Link, LinkValue, Listing,
-	ListingKind, Manga, MangaPageResult, NotificationHandler, Result, Source,
+	HomeComponent, HomeLayout, Link, LinkValue, Listing, ListingKind, Manga, MangaPageResult,
+	Result, Source,
 };
 use gigaviewer::{GigaViewer, Impl, Params};
 

--- a/sources/ja.mangamura/Cargo.lock
+++ b/sources/ja.mangamura/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "aidoku"
 version = "0.3.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git?branch=next#99eeb7e5906160f7c0d21003dd5a7a0b7c6be507"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#d922d82068d18b0c115a2185a86cbc3e849e739b"
 dependencies = [
  "chrono",
  "euclid",
@@ -32,7 +32,7 @@ dependencies = [
 [[package]]
 name = "aidoku-test"
 version = "1.0.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git?branch=next#99eeb7e5906160f7c0d21003dd5a7a0b7c6be507"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#d922d82068d18b0c115a2185a86cbc3e849e739b"
 dependencies = [
  "quote",
  "syn",
@@ -82,9 +82,12 @@ dependencies = [
 
 [[package]]
 name = "cobs"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "critical-section"
@@ -211,9 +214,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "postcard"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
+checksum = "6c1de96e20f51df24ca73cafcc4690e044854d803259db27a00a461cb3b9d17a"
 dependencies = [
  "cobs",
  "embedded-io 0.4.0",
@@ -332,6 +335,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3ae828aa394de34c7de08f522d1b86bd1c182c668d27da69caadda00590f26d"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/sources/ja.mangamura/Cargo.toml
+++ b/sources/ja.mangamura/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next", version = "0.3.0" }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", version = "0.3.0" }
 mangareader = { path = "../../templates/mangareader" }
 
 [dev-dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next", features = ["test"] }
-aidoku-test = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next" }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", features = ["test"] }
+aidoku-test = { git = "https://github.com/Aidoku/aidoku-rs.git" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/sources/ja.rawotaku/Cargo.lock
+++ b/sources/ja.rawotaku/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "aidoku"
 version = "0.3.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git?branch=next#99eeb7e5906160f7c0d21003dd5a7a0b7c6be507"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#d922d82068d18b0c115a2185a86cbc3e849e739b"
 dependencies = [
  "chrono",
  "euclid",
@@ -32,7 +32,7 @@ dependencies = [
 [[package]]
 name = "aidoku-test"
 version = "1.0.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git?branch=next#99eeb7e5906160f7c0d21003dd5a7a0b7c6be507"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#d922d82068d18b0c115a2185a86cbc3e849e739b"
 dependencies = [
  "quote",
  "syn",
@@ -82,9 +82,12 @@ dependencies = [
 
 [[package]]
 name = "cobs"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "critical-section"
@@ -202,9 +205,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "postcard"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
+checksum = "6c1de96e20f51df24ca73cafcc4690e044854d803259db27a00a461cb3b9d17a"
 dependencies = [
  "cobs",
  "embedded-io 0.4.0",
@@ -332,6 +335,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3ae828aa394de34c7de08f522d1b86bd1c182c668d27da69caadda00590f26d"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/sources/ja.rawotaku/Cargo.toml
+++ b/sources/ja.rawotaku/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next", version = "0.3.0" }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", version = "0.3.0" }
 mangareader = { path = "../../templates/mangareader" }
 
 [dev-dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next", features = ["test"] }
-aidoku-test = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next" }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", features = ["test"] }
+aidoku-test = { git = "https://github.com/Aidoku/aidoku-rs.git" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/sources/ja.shonenjumpplus/Cargo.lock
+++ b/sources/ja.shonenjumpplus/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "aidoku"
 version = "0.3.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git?branch=next#6323347cd04e69ed035aab315bbe0dce5803fe12"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#d922d82068d18b0c115a2185a86cbc3e849e739b"
 dependencies = [
  "chrono",
  "euclid",
@@ -32,7 +32,7 @@ dependencies = [
 [[package]]
 name = "aidoku-test"
 version = "1.0.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git?branch=next#6323347cd04e69ed035aab315bbe0dce5803fe12"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#d922d82068d18b0c115a2185a86cbc3e849e739b"
 dependencies = [
  "quote",
  "syn",
@@ -82,9 +82,12 @@ dependencies = [
 
 [[package]]
 name = "cobs"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "critical-section"
@@ -202,9 +205,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "postcard"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
+checksum = "6c1de96e20f51df24ca73cafcc4690e044854d803259db27a00a461cb3b9d17a"
 dependencies = [
  "cobs",
  "embedded-io 0.4.0",
@@ -316,9 +319,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -332,6 +335,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3ae828aa394de34c7de08f522d1b86bd1c182c668d27da69caadda00590f26d"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/sources/ja.shonenjumpplus/Cargo.toml
+++ b/sources/ja.shonenjumpplus/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next", version = "0.3.0" }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", version = "0.3.0" }
 gigaviewer = { path = "../../templates/gigaviewer" }
 
 [dev-dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next", features = ["test"] }
-aidoku-test = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next" }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", features = ["test"] }
+aidoku-test = { git = "https://github.com/Aidoku/aidoku-rs.git" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/sources/ja.shonenjumpplus/src/lib.rs
+++ b/sources/ja.shonenjumpplus/src/lib.rs
@@ -3,8 +3,7 @@ use aidoku::{
 	alloc::{vec, Vec},
 	imports::{html::Document, net::Request},
 	prelude::*,
-	BasicLoginHandler, DeepLinkHandler, Home, HomeComponent, HomeLayout, Link, Listing,
-	ListingProvider, MangaPageResult, NotificationHandler, Result, Source,
+	HomeComponent, HomeLayout, Link, Listing, MangaPageResult, Result, Source,
 };
 use gigaviewer::{GigaViewer, Impl, Params};
 

--- a/sources/multi.mangadex/Cargo.lock
+++ b/sources/multi.mangadex/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "aidoku"
 version = "0.3.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git?branch=next#2e2d4c7f978b02363f38775b5955a35fe94a598b"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#d922d82068d18b0c115a2185a86cbc3e849e739b"
 dependencies = [
  "chrono",
  "euclid",
@@ -32,7 +32,7 @@ dependencies = [
 [[package]]
 name = "aidoku-test"
 version = "1.0.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git?branch=next#2e2d4c7f978b02363f38775b5955a35fe94a598b"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#d922d82068d18b0c115a2185a86cbc3e849e739b"
 dependencies = [
  "quote",
  "syn",
@@ -82,9 +82,12 @@ dependencies = [
 
 [[package]]
 name = "cobs"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "critical-section"
@@ -214,9 +217,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "postcard"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
+checksum = "6c1de96e20f51df24ca73cafcc4690e044854d803259db27a00a461cb3b9d17a"
 dependencies = [
  "cobs",
  "embedded-io 0.4.0",
@@ -319,9 +322,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -335,6 +338,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3ae828aa394de34c7de08f522d1b86bd1c182c668d27da69caadda00590f26d"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/sources/multi.mangadex/Cargo.toml
+++ b/sources/multi.mangadex/Cargo.toml
@@ -4,15 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next", version = "0.3.0", features = ["json"] }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", version = "0.3.0", features = ["json"] }
 serde = { version = "1.0.188", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1.0.105", default-features = false, features = ["alloc"] }
 chrono = { version = "0.4.30", default-features = false, features = ["alloc"] }
 hashbrown = "0.13.2"
 
 [dev-dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next", features = ["test"] }
-aidoku-test = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next" }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", features = ["test"] }
+aidoku-test = { git = "https://github.com/Aidoku/aidoku-rs.git" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/sources/multi.mangadex/src/lib.rs
+++ b/sources/multi.mangadex/src/lib.rs
@@ -9,7 +9,7 @@ use aidoku::{
 	},
 	prelude::*,
 	AlternateCoverProvider, Chapter, DeepLinkHandler, DeepLinkResult, DynamicListings, FilterValue,
-	Home, Listing, ListingKind, ListingProvider, Manga, MangaPageResult, Page, PageContent, Result,
+	Listing, ListingKind, ListingProvider, Manga, MangaPageResult, Page, PageContent, Result,
 	Source,
 };
 use core::fmt::Write;

--- a/templates/gigaviewer/Cargo.lock
+++ b/templates/gigaviewer/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "aidoku"
 version = "0.3.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git?branch=next#6323347cd04e69ed035aab315bbe0dce5803fe12"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#d922d82068d18b0c115a2185a86cbc3e849e739b"
 dependencies = [
  "chrono",
  "euclid",
@@ -32,7 +32,7 @@ dependencies = [
 [[package]]
 name = "aidoku-test"
 version = "1.0.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git?branch=next#6323347cd04e69ed035aab315bbe0dce5803fe12"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#d922d82068d18b0c115a2185a86cbc3e849e739b"
 dependencies = [
  "quote",
  "syn",
@@ -82,9 +82,12 @@ dependencies = [
 
 [[package]]
 name = "cobs"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "critical-section"
@@ -203,9 +206,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "postcard"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
+checksum = "6c1de96e20f51df24ca73cafcc4690e044854d803259db27a00a461cb3b9d17a"
 dependencies = [
  "cobs",
  "embedded-io 0.4.0",
@@ -308,9 +311,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -324,6 +327,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3ae828aa394de34c7de08f522d1b86bd1c182c668d27da69caadda00590f26d"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/templates/gigaviewer/Cargo.toml
+++ b/templates/gigaviewer/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next", version = "0.3.0", features = ["json"] }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", version = "0.3.0", features = ["json"] }
 serde = { version = "1.0.188", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1.0.105", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next", features = ["test"] }
-aidoku-test = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next" }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", features = ["test"] }
+aidoku-test = { git = "https://github.com/Aidoku/aidoku-rs.git" }

--- a/templates/mangabox/Cargo.lock
+++ b/templates/mangabox/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "aidoku"
 version = "0.3.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git?branch=next#2e2d4c7f978b02363f38775b5955a35fe94a598b"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#d922d82068d18b0c115a2185a86cbc3e849e739b"
 dependencies = [
  "chrono",
  "euclid",
@@ -32,7 +32,7 @@ dependencies = [
 [[package]]
 name = "aidoku-test"
 version = "1.0.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git?branch=next#2e2d4c7f978b02363f38775b5955a35fe94a598b"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#d922d82068d18b0c115a2185a86cbc3e849e739b"
 dependencies = [
  "quote",
  "syn",
@@ -82,9 +82,12 @@ dependencies = [
 
 [[package]]
 name = "cobs"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "critical-section"
@@ -203,9 +206,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "postcard"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
+checksum = "6c1de96e20f51df24ca73cafcc4690e044854d803259db27a00a461cb3b9d17a"
 dependencies = [
  "cobs",
  "embedded-io 0.4.0",
@@ -324,6 +327,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3ae828aa394de34c7de08f522d1b86bd1c182c668d27da69caadda00590f26d"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/templates/mangabox/Cargo.toml
+++ b/templates/mangabox/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next", version = "0.3.0", features = ["json"] }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", version = "0.3.0", features = ["json"] }
 serde = { version = "1.0.188", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1.0.105", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next", features = ["test"] }
-aidoku-test = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next" }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", features = ["test"] }
+aidoku-test = { git = "https://github.com/Aidoku/aidoku-rs.git" }

--- a/templates/mangareader/Cargo.lock
+++ b/templates/mangareader/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "aidoku"
 version = "0.3.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git?branch=next#99eeb7e5906160f7c0d21003dd5a7a0b7c6be507"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#d922d82068d18b0c115a2185a86cbc3e849e739b"
 dependencies = [
  "chrono",
  "euclid",
@@ -32,7 +32,7 @@ dependencies = [
 [[package]]
 name = "aidoku-test"
 version = "1.0.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git?branch=next#99eeb7e5906160f7c0d21003dd5a7a0b7c6be507"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#d922d82068d18b0c115a2185a86cbc3e849e739b"
 dependencies = [
  "quote",
  "syn",
@@ -82,9 +82,12 @@ dependencies = [
 
 [[package]]
 name = "cobs"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "critical-section"
@@ -203,9 +206,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "postcard"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
+checksum = "6c1de96e20f51df24ca73cafcc4690e044854d803259db27a00a461cb3b9d17a"
 dependencies = [
  "cobs",
  "embedded-io 0.4.0",
@@ -324,6 +327,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3ae828aa394de34c7de08f522d1b86bd1c182c668d27da69caadda00590f26d"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/templates/mangareader/Cargo.toml
+++ b/templates/mangareader/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next", version = "0.3.0", features = ["json"]}
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", version = "0.3.0", features = ["json"]}
 serde = { version = "1.0.188", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1.0.105", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next", features = ["test", "json"] }
-aidoku-test = { git = "https://github.com/Aidoku/aidoku-rs.git", branch = "next" }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", features = ["test", "json"] }
+aidoku-test = { git = "https://github.com/Aidoku/aidoku-rs.git" }


### PR DESCRIPTION
the new aidoku-rs moved to the main branch

updated all sources to point towards the main branch and use the current latest version