### PR TITLE
feat: add webpage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,10 @@
 .build
 *.aix
 
-public/
+public/icons/
+public/sources/
+public/*.json
+
 sources/*/target
 sources/*/public
 templates/*/target

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository hosts unofficial sources maintained by community members that ar
 
 ## Usage
 
-On a device with Aidoku (0.7+) installed, you can open [this link](https://aidoku.app/add-source-list/?url=https://aidoku-community.github.io/sources/index.min.json) to add the source list directly to the app.
+On a device with Aidoku (0.7+) installed, you can open [https://aidoku-community.github.io/sources/](https://aidoku-community.github.io/sources/) and click the "Add Repository" button to add the source list directly to the app.
 
 Otherwise, navigate to the settings tab, and under the source lists page add `https://aidoku-community.github.io/sources/index.min.json`.
 

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,166 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
+		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+		<meta
+			name="description"
+			content="Unofficial Aidoku sources maintained by community members."
+		/>
+		<title>Aidoku Community Sources</title>
+		<link
+			rel="canonical"
+			href="https://aidoku-community.github.io/sources/"
+		/>
+		<meta property="og:title" content="Aidoku Community Sources" />
+		<meta
+			property="og:description"
+			content="Unofficial Aidoku sources maintained by community members."
+		/>
+		<meta
+			property="og:url"
+			content="https://aidoku-community.github.io/sources/"
+		/>
+		<link rel="stylesheet" href="styles.css" />
+	</head>
+	<body>
+		<a
+			href="https://github.com/aidoku-community/sources"
+			id="github-link"
+			target="_blank"
+			rel="noopener"
+			aria-label="GitHub Repository"
+		>
+			<svg
+				viewBox="0 0 16 16"
+				width="28"
+				height="28"
+				fill="currentColor"
+				aria-hidden="true"
+			>
+				<path
+					d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38
+					0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52
+					-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2
+					-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64
+					-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08
+					2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01
+					1.93-.01 2.19 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
+				/>
+			</svg>
+		</a>
+		<header>
+			<h1 class="main-heading">Aidoku Community Sources</h1>
+			<p class="main-description">
+				Download unofficial Aidoku sources maintained by community
+				members. Add this repository to Aidoku to install and update
+				sources from within the app.
+			</p>
+		</header>
+		<main>
+			<div id="add-repo-btn" style="display: none">
+				<button
+					onclick='window.location = "aidoku://addSourceList?url=https://aidoku-community.github.io/sources/index.min.json";'
+				>
+					Add Repository
+				</button>
+				<p>Requires <b>Aidoku 0.7</b> or newer.</p>
+			</div>
+			<div id="non-apple-note" style="display: none">
+				<p>
+					You can add this repository inside the Aidoku app in the
+					<b>Settings</b> tab under <b>Source Lists</b> by entering:
+					<code>
+						https://aidoku-community.github.io/sources/index.min.json
+					</code>
+				</p>
+			</div>
+			<div id="filter-container">
+				<div class="filter-group">
+					<label for="source-search" class="filter-label">
+						Search
+					</label>
+					<input
+						type="text"
+						id="source-search"
+						placeholder="Search sources..."
+						autocomplete="off"
+					/>
+				</div>
+				<div id="filter-menus-row">
+					<div class="filter-group">
+						<label for="language-select" class="filter-label">
+							Language
+						</label>
+						<div class="select-wrapper">
+							<select id="language-select">
+								<option value="">All Languages</option>
+							</select>
+							<svg
+								class="select-chevron"
+								xmlns="http://www.w3.org/2000/svg"
+								viewBox="0 0 1024 1024"
+								width="18"
+								height="18"
+							>
+								<path
+									fill="currentColor"
+									d="M831.872 340.864 512 652.672 192.128 340.864a30.592 30.592 0 0 0-42.752 0 29.12 29.12 0 0 0 0 41.6L489.664 714.24a32 32 0 0 0 44.672 0l340.288-331.712a29.12 29.12 0 0 0 0-41.728 30.592 30.592 0 0 0-42.752 0z"
+								></path>
+							</svg>
+						</div>
+					</div>
+					<div class="filter-group">
+						<label for="rating-select" class="filter-label">
+							Content Rating
+						</label>
+						<div class="select-wrapper">
+							<select id="rating-select">
+								<option value="">All Content Ratings</option>
+								<option value="safe">Safe</option>
+								<option value="contains-nsfw">
+									Contains NSFW
+								</option>
+								<option value="nsfw">NSFW</option>
+							</select>
+							<svg
+								class="select-chevron"
+								xmlns="http://www.w3.org/2000/svg"
+								viewBox="0 0 1024 1024"
+								width="18"
+								height="18"
+							>
+								<path
+									fill="currentColor"
+									d="M831.872 340.864 512 652.672 192.128 340.864a30.592 30.592 0 0 0-42.752 0 29.12 29.12 0 0 0 0 41.6L489.664 714.24a32 32 0 0 0 44.672 0l340.288-331.712a29.12 29.12 0 0 0 0-41.728 30.592 30.592 0 0 0-42.752 0z"
+								></path>
+							</svg>
+						</div>
+					</div>
+				</div>
+			</div>
+			<noscript>
+				You need to enable JavaScript to see and filter sources.
+			</noscript>
+			<div class="source-list-header-row">
+				<span class="total-count" id="total-count"></span>
+			</div>
+			<div id="source-list"></div>
+		</main>
+		<script>
+			// show the add repo button if the user agent is an apple device, otherwise show note
+			(function () {
+				const ua = navigator.userAgent.toLowerCase();
+				const isApple = /iphone|ipad|ipados|macintosh|mac os x/.test(
+					ua,
+				);
+				const btn = document.getElementById("add-repo-btn");
+				const note = document.getElementById("non-apple-note");
+				if (btn && isApple) btn.style.display = "";
+				if (note && !isApple) note.style.display = "";
+			})();
+		</script>
+		<script src="main.js" defer></script>
+	</body>
+</html>

--- a/public/main.js
+++ b/public/main.js
@@ -1,0 +1,343 @@
+document.addEventListener("DOMContentLoaded", () => {
+	const sourceList = document.getElementById("source-list");
+	const searchBar = document.getElementById("source-search");
+	const languageSelect = document.getElementById("language-select");
+	const ratingSelect = document.getElementById("rating-select");
+
+	const langMap = {
+		en: "English",
+		es: "Spanish",
+		fr: "French",
+		de: "German",
+		ja: "Japanese",
+		zh: "Chinese",
+		ru: "Russian",
+		it: "Italian",
+		ko: "Korean",
+		pt: "Portuguese",
+		id: "Indonesian",
+		th: "Thai",
+		vi: "Vietnamese",
+		tr: "Turkish",
+		pl: "Polish",
+		ar: "Arabic",
+		hi: "Hindi",
+	};
+	const labelToCode = Object.fromEntries(
+		Object.entries(langMap).map(([code, label]) => [label, code]),
+	);
+	function getLanguageLabel(languages) {
+		if (!Array.isArray(languages) || languages.length === 0)
+			return "Unknown";
+		if (languages.length > 1 || languages.includes("multi"))
+			return "Multi-Language";
+		return langMap[languages[0]] || languages[0];
+	}
+
+	// store filter state, sources, and the source dom elements
+	const filterState = {
+		query: "",
+		language: "",
+		rating: "",
+	};
+	let allSources = [];
+	let allSourceElements = [];
+
+	// filter sources and hide filtered out elements
+	function filterAndShowSources() {
+		let visibleCount = 0;
+		const sectionToVisible = new Map();
+		for (const { source, li, section } of allSourceElements) {
+			// check language
+			const languageLabel = getLanguageLabel(source.languages);
+			const languageMatch =
+				!filterState.language ||
+				filterState.language === "" ||
+				(filterState.language === "Multi-Language" &&
+					languageLabel === "Multi-Language") ||
+				languageLabel === filterState.language ||
+				(filterState.language !== "" &&
+					filterState.language !== "Multi-Language" &&
+					languageLabel === "Multi-Language" &&
+					Array.isArray(source.languages) &&
+					source.languages.includes(
+						labelToCode[filterState.language],
+					));
+
+			// check content rating
+			let ratingMatch = true;
+			if (filterState.rating === "safe") {
+				ratingMatch =
+					!source.contentRating || source.contentRating === 0;
+			} else if (filterState.rating === "contains-nsfw") {
+				ratingMatch = source.contentRating === 1;
+			} else if (filterState.rating === "nsfw") {
+				ratingMatch = source.contentRating === 2;
+			}
+
+			// check search query (match name, alt name, or url)
+			const q = filterState.query.trim().toLowerCase();
+			const nameMatch =
+				!q || (source.name && source.name.toLowerCase().includes(q));
+			const altNames = Array.isArray(source.altNames)
+				? source.altNames
+				: [];
+			const altMatch = !q
+				? true
+				: altNames.some((alt) => alt && alt.toLowerCase().includes(q));
+			const urlMatch = !q
+				? true
+				: source.baseURL && source.baseURL.toLowerCase().includes(q);
+			const queryMatch = nameMatch || altMatch || urlMatch;
+
+			const shouldShow = languageMatch && ratingMatch && queryMatch;
+			li.style.display = shouldShow ? "" : "none";
+			if (shouldShow) {
+				visibleCount++;
+				sectionToVisible.set(
+					section,
+					(sectionToVisible.get(section) || 0) + 1,
+				);
+			}
+		}
+
+		// hide sections if they don't have any visible children
+		const allSections = document.querySelectorAll(".language-section");
+		allSections.forEach((section) => {
+			const visible = sectionToVisible.get(section) || 0;
+			section.style.display = visible > 0 ? "" : "none";
+		});
+
+		// update total source count
+		const totalCountSpan = document.querySelector(".total-count");
+		if (totalCountSpan) {
+			totalCountSpan.textContent = "Total: " + visibleCount;
+		}
+	}
+
+	// add event listeners for filter changes
+	searchBar.addEventListener("input", (e) => {
+		filterState.query = e.target.value;
+		filterAndShowSources();
+	});
+	languageSelect.addEventListener("change", (e) => {
+		filterState.language = e.target.value;
+		filterAndShowSources();
+	});
+	ratingSelect.addEventListener("change", (e) => {
+		filterState.rating = e.target.value;
+		filterAndShowSources();
+	});
+
+	// fetch and render initial sources from index.min.json
+	fetch("index.min.json")
+		.then((response) => {
+			if (!response.ok) throw new Error("Failed to load sources");
+			return response.json();
+		})
+		.then((data) => {
+			if (
+				!data.sources ||
+				!Array.isArray(data.sources) ||
+				data.sources.length === 0
+			) {
+				sourceList.textContent = "No sources found.";
+				return;
+			}
+
+			allSources = data.sources;
+
+			// populate language dropdown
+			const languageSet = new Set();
+			allSources.forEach((source) => {
+				const label = getLanguageLabel(source.languages);
+				languageSet.add(label);
+			});
+			const languageList = Array.from(languageSet).sort((a, b) => {
+				if (a === "Multi-Language") return -1;
+				if (b === "Multi-Language") return 1;
+				return a.localeCompare(b);
+			});
+			languageList.forEach((lang) => {
+				if (
+					[...languageSelect.options].some(
+						(opt) => opt.value === lang,
+					)
+				)
+					return;
+				const opt = document.createElement("option");
+				opt.value = lang;
+				opt.textContent = lang;
+				languageSelect.appendChild(opt);
+			});
+
+			// apply language label to sources
+			const sources = allSources.map((source) => {
+				let languageLabel = getLanguageLabel(source.languages);
+				let sortLang =
+					languageLabel === "Multi-Language"
+						? ""
+						: languageLabel.toLowerCase();
+				return {
+					...source,
+					languageLabel,
+					sortLang,
+				};
+			});
+
+			// sort by language and name
+			sources.sort((a, b) => {
+				if (a.sortLang !== b.sortLang) {
+					return a.sortLang.localeCompare(b.sortLang);
+				}
+				// sort alphabetically if language is the same
+				return a.name.localeCompare(b.name);
+			});
+
+			// group by language label
+			const grouped = {};
+			sources.forEach((source) => {
+				if (!grouped[source.languageLabel]) {
+					grouped[source.languageLabel] = [];
+				}
+				grouped[source.languageLabel].push(source);
+			});
+
+			// render source cells
+			sourceList.innerHTML = "";
+			allSourceElements = [];
+			let isFirst = true;
+			Object.keys(grouped).forEach((language) => {
+				// create a section for the language group
+				const section = document.createElement("section");
+				section.className = "language-section";
+				section.setAttribute("data-lang-label", language);
+
+				// language header
+				const headerRow = document.createElement("div");
+				headerRow.className = "language-header-row";
+				const langHeader = document.createElement("h2");
+				langHeader.textContent = language;
+
+				headerRow.appendChild(langHeader);
+				section.appendChild(headerRow);
+
+				// source list
+				const ul = document.createElement("ul");
+				grouped[language].forEach((source) => {
+					const li = document.createElement("li");
+					li.className = "source-row";
+					li.setAttribute("data-name", source.name.toLowerCase());
+					li.setAttribute("data-version", String(source.version));
+					li.setAttribute(
+						"data-languages",
+						(source.languages || []).join(","),
+					);
+					li.setAttribute(
+						"data-content-rating",
+						source.contentRating != null
+							? String(source.contentRating)
+							: "0",
+					);
+					li.setAttribute("data-lang-label", language);
+
+					const leftDiv = document.createElement("div");
+					leftDiv.className = "source-left";
+
+					const infoWrapper = document.createElement("div");
+					infoWrapper.className = "source-info-wrapper";
+
+					if (source.iconURL) {
+						const icon = document.createElement("img");
+						icon.src = source.iconURL;
+						icon.alt = source.name + " icon";
+						icon.className = "source-icon";
+						infoWrapper.appendChild(icon);
+					}
+
+					const infoRowStack = document.createElement("div");
+					infoRowStack.className = "source-info-row-stack";
+
+					const titleRow = document.createElement("div");
+					titleRow.className = "source-title-row";
+
+					const name = document.createElement("span");
+					name.textContent = source.name;
+					titleRow.appendChild(name);
+
+					const version = document.createElement("span");
+					version.textContent = " v" + source.version;
+					version.className = "source-version";
+					titleRow.appendChild(version);
+
+					let ratingBadge = null;
+					if (
+						source.contentRating === 1 ||
+						source.contentRating === 2
+					) {
+						ratingBadge = document.createElement("span");
+						ratingBadge.className =
+							"source-rating-badge " +
+							(source.contentRating === 1
+								? "source-rating-17"
+								: "source-rating-18");
+						ratingBadge.textContent =
+							source.contentRating === 1 ? "17+" : "18+";
+						const tooltip = document.createElement("span");
+						tooltip.className = "tooltip";
+						tooltip.textContent =
+							source.contentRating === 1
+								? "This source contains NSFW content"
+								: "This source contains primarily NSFW content";
+						ratingBadge.appendChild(tooltip);
+						ratingBadge.addEventListener("mouseenter", () => {
+							tooltip.style.opacity = "1";
+							tooltip.style.pointerEvents = "auto";
+						});
+						ratingBadge.addEventListener("mouseleave", () => {
+							tooltip.style.opacity = "0";
+							tooltip.style.pointerEvents = "none";
+						});
+					}
+					if (ratingBadge) titleRow.appendChild(ratingBadge);
+
+					infoRowStack.appendChild(titleRow);
+
+					if (source.baseURL) {
+						const urlRow = document.createElement("div");
+						urlRow.className = "source-url";
+						urlRow.textContent = source.baseURL;
+						infoRowStack.appendChild(urlRow);
+					}
+
+					infoWrapper.appendChild(infoRowStack);
+					leftDiv.appendChild(infoWrapper);
+					const rightDiv = document.createElement("div");
+					rightDiv.className = "source-right";
+
+					const button = document.createElement("a");
+					button.href = source.downloadURL;
+					button.textContent = "↓";
+					button.setAttribute("download", "");
+					button.className = "source-download";
+					rightDiv.appendChild(button);
+
+					li.appendChild(leftDiv);
+					li.appendChild(rightDiv);
+
+					ul.appendChild(li);
+
+					allSourceElements.push({ source, li, section });
+				});
+				section.appendChild(ul);
+				sourceList.appendChild(section);
+			});
+
+			// initial filter
+			filterAndShowSources();
+		})
+		.catch((error) => {
+			sourceList.textContent = "Error loading sources.";
+			console.error(error);
+		});
+});

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,434 @@
+:root {
+	--bg: #fff;
+	--fg: rgb(29, 29, 31);
+	--highlight: #f1f3f6;
+	--border: #e0e0e0;
+	--gray: rgb(110, 110, 115);
+	--badge-fg: #444;
+	--badge-17-bg: rgba(255, 162, 0, 0.3);
+	--badge-18-bg: rgba(229, 56, 53, 0.3);
+	--button-bg: #ff2f52;
+	--button-bg-hover: #e82c4b;
+	--input-bg: #fff;
+	--input-fg: #18191a;
+	--input-border: #e0e0e0;
+	--github-icon: #181717;
+}
+
+@media (prefers-color-scheme: dark) {
+	:root {
+		--bg: #181a1c;
+		--fg: #f3f3f3;
+		--highlight: #23272e;
+		--border: #33363a;
+		--gray: #888;
+		--badge-fg: #999;
+		--button-bg-hover: #fc4463;
+		--input-bg: #23272e;
+		--input-fg: #f3f3f3;
+		--input-border: #33363a;
+		--github-icon: #888;
+	}
+}
+
+html {
+	font-family:
+		"Inter", system-ui, "Helvetica Neue", Helvetica, Arial, sans-serif;
+	background: var(--bg);
+	color: var(--fg);
+	overflow-y: scroll;
+}
+
+body {
+	margin: 0;
+	padding: 0;
+	background: var(--bg);
+	color: var(--fg);
+	scrollbar-gutter: stable;
+}
+
+/* header */
+header {
+	max-width: 700px;
+	margin: 2rem auto 1.3em auto;
+	padding: 1.5rem 1.5rem 0rem 1.5rem;
+}
+
+header > h1 {
+	font-size: 2.1em;
+	font-weight: 700;
+	margin-bottom: 0.3em;
+}
+
+header > p {
+	color: var(--gray);
+	font-size: 1.08em;
+	margin-top: 0;
+	line-height: 1.5;
+	max-width: 600px;
+}
+
+/* main content */
+main {
+	max-width: 700px;
+	margin: 1.3rem auto 2rem auto;
+	padding: 0rem 1.5rem 2rem 1.5rem;
+}
+
+/* github icon */
+#github-link {
+	position: fixed;
+	top: 1.5rem;
+	right: 1.5rem;
+	z-index: 100;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	text-decoration: none;
+	background: none;
+	border: none;
+	padding: 0;
+}
+#github-link svg {
+	width: 32px;
+	height: 32px;
+	fill: var(--github-icon);
+	transition: fill 0.15s;
+	display: block;
+}
+#github-link:focus svg,
+#github-link:hover svg {
+	fill: var(--button-bg);
+}
+@media (max-width: 600px) {
+	#github-link {
+		top: 0.7rem;
+		right: 0.7rem;
+	}
+	#github-link svg {
+		width: 26px;
+		height: 26px;
+	}
+}
+
+/* add repository button */
+#add-repo-btn {
+	margin-bottom: 1.3em;
+}
+
+#add-repo-btn > button {
+	width: 100%;
+	padding: 0.6em 1.2em;
+	font-size: 1em;
+	font-weight: 500;
+	border-radius: 0.6em;
+	border: 1.5px solid var(--button-bg);
+	background: var(--button-bg);
+	color: #fff;
+	cursor: pointer;
+	transition:
+		background 0.15s,
+		border-color 0.15s;
+}
+#add-repo-btn > button:hover,
+#add-repo-btn > button:focus {
+	background: var(--button-bg-hover);
+	border-color: var(--button-bg-hover);
+}
+
+/* requires aidoku version text */
+#add-repo-btn > p {
+	color: var(--gray);
+	margin: 0.8em 0;
+}
+#add-repo-btn > p > b {
+	color: var(--fg);
+	font-weight: 600;
+}
+
+/* app repo instructions */
+#non-apple-note {
+	background: var(--input-bg);
+	color: var(--input-fg);
+	border-radius: 0.8em;
+	padding: 0em 1em;
+	margin-bottom: 1.3em;
+	border: 1.5px solid var(--input-border);
+	line-height: 1.4;
+}
+#non-apple-note code {
+	display: inline;
+	background: var(--highlight);
+	padding: 0.15em 0.4em;
+	border-radius: 0.4em;
+	font-size: 0.98em;
+}
+
+/* filters (search and selects) */
+#filter-container {
+	display: flex;
+	flex-direction: column;
+	gap: 1.3em;
+	margin-bottom: 1.5em;
+	align-items: stretch;
+}
+
+/* filter labels */
+.filter-label {
+	color: var(--gray);
+	font-size: 1em;
+	font-weight: 500;
+	margin-bottom: 0.18em;
+	white-space: nowrap;
+}
+
+.filter-group {
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
+	gap: 0.4em;
+}
+
+/* search bar */
+#source-search {
+	display: block;
+	width: 100%;
+	font-size: 1em;
+	padding: 0.6em 1em;
+	border-radius: 0.6em;
+	border: 1.5px solid var(--input-border);
+	background: var(--input-bg);
+	color: var(--input-fg);
+	transition:
+		border-color 0.15s,
+		background 0.15s;
+	box-sizing: border-box;
+}
+#source-search:focus {
+	outline: none;
+	border-color: var(--button-bg);
+}
+
+/* select filters  */
+#filter-menus-row {
+	display: flex;
+	flex-direction: row;
+	gap: 1em;
+	width: 100%;
+}
+#filter-menus-row .filter-group {
+	flex: 1 1 0;
+	min-width: 0;
+}
+@media (max-width: 600px) {
+	#filter-menus-row {
+		flex-direction: column;
+	}
+	#filter-menus-row .filter-group {
+		width: 100%;
+	}
+}
+
+.select-wrapper {
+	position: relative;
+	display: inline-block;
+	width: 100%;
+}
+
+#language-select,
+#rating-select {
+	font-size: 1em;
+	padding: 0.55em 2.2em 0.55em 1em;
+	border-radius: 0.6em;
+	border: 1.5px solid var(--input-border);
+	background: var(--input-bg);
+	color: var(--input-fg);
+	transition:
+		border-color 0.15s,
+		background 0.15s;
+	appearance: none;
+	-webkit-appearance: none;
+	margin-right: 0.2em;
+	width: 100%;
+	box-sizing: border-box;
+}
+#language-select:focus,
+#rating-select:focus {
+	outline: none;
+	border-color: var(--button-bg);
+}
+
+/* chevron svg for select menus */
+.select-chevron {
+	position: absolute;
+	right: 0.9em;
+	top: 50%;
+	transform: translateY(-50%);
+	width: 18px;
+	height: 18px;
+	pointer-events: none;
+	color: var(--gray);
+	z-index: 2;
+}
+
+/* source list */
+#source-list ul {
+	list-style: none;
+	padding: 0.5em 0;
+	margin: 0;
+	margin-bottom: 0.5em;
+}
+
+#source-list h2 {
+	font-size: 1.08em;
+	font-weight: 500;
+	color: var(--gray);
+	letter-spacing: 0.01em;
+	display: inline-block;
+	margin: 0;
+	flex: 1 1 auto;
+}
+
+.source-list-header-row {
+	position: relative;
+	height: 0;
+}
+
+.total-count {
+	position: absolute;
+	top: 0;
+	right: 0.5em;
+	color: var(--gray);
+	font-size: 1.03em;
+	font-weight: 500;
+	margin-bottom: 0;
+	margin-top: 0;
+	margin-left: 1em;
+	white-space: nowrap;
+	pointer-events: none;
+	background: transparent;
+}
+
+.language-header-row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 0;
+}
+
+.source-download {
+	display: inline-block;
+	font-size: 1.25em;
+	margin-left: 1em;
+	border-radius: 0.5em;
+	background: none;
+	border: none;
+	color: var(--button-bg);
+	text-decoration: none;
+	cursor: pointer;
+	vertical-align: middle;
+	line-height: 1;
+}
+
+#source-list li {
+	font-size: 1.1em;
+	display: flex;
+	align-items: center;
+	padding: 0.5em 0.75em;
+	margin: 0 -0.75em;
+	margin-bottom: 0.25em;
+	transition: background 0.15s;
+	border-radius: 0.75em;
+}
+#source-list li:hover {
+	background: var(--highlight);
+	border-radius: 0.75em;
+}
+
+.source-left {
+	display: flex;
+	flex-direction: column;
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+/* contains source icon, title, version, badge, and url */
+.source-info-wrapper {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+.source-icon {
+	width: 40px;
+	height: 40px;
+	object-fit: cover;
+	border-radius: 9px;
+	margin-right: 0.6em;
+}
+
+/* source title row and url subtitle */
+.source-info-row-stack {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	gap: 0.1em;
+	min-width: 0;
+}
+
+/* source title, version, badge */
+.source-title-row {
+	display: flex;
+	align-items: center;
+	gap: 0.3em;
+}
+
+.source-version {
+	color: var(--gray);
+	font-size: 0.95em;
+}
+
+.source-rating-badge {
+	display: inline-block;
+	padding: 0.15em 0.4em;
+	border-radius: 0.4em;
+	font-size: 0.8em;
+	margin-left: 0.5em;
+	vertical-align: middle;
+	color: var(--badge-fg);
+	position: relative;
+}
+.source-rating-17 {
+	background: var(--badge-17-bg);
+}
+.source-rating-18 {
+	background: var(--badge-18-bg);
+}
+
+.source-url {
+	color: var(--gray);
+	font-size: 0.8em;
+	margin-top: 0.2em;
+	word-break: break-all;
+}
+
+/* content rating badge tooltip */
+.tooltip {
+	position: absolute;
+	left: 50%;
+	bottom: 120%;
+	transform: translateX(-50%);
+	background: var(--fg);
+	color: var(--bg);
+	padding: 0.5em;
+	border-radius: 0.5em;
+	font-size: 0.95em;
+	white-space: nowrap;
+	box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.1);
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 0.08s;
+	z-index: 10;
+}


### PR DESCRIPTION
I made a quick webpage that lists the available sources and serve as a better way to link people to this repo. 

it might be beneficial to have more information on this page in the future, for example how and when to create issues, which could be coupled along with issue templates. however, this should do for now.

it also might be better placed directly on https://aidoku-community.github.io, which has nothing on it, and could use something, instead of the /sources path, but that would complicate things a little bit. it might be better if we had a domain with this page as the root.