### PR TITLE
fix(multi.mangadex): fix wrong sort from alt cover art, add show locked chapters & current seasonal list

### DIFF
--- a/sources/multi.mangadex/Cargo.lock
+++ b/sources/multi.mangadex/Cargo.lock
@@ -189,6 +189,7 @@ dependencies = [
  "aidoku-test",
  "chrono",
  "hashbrown 0.13.2",
+ "regex",
  "serde",
  "serde_json",
 ]
@@ -245,6 +246,31 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
+dependencies = [
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "rustc_version"

--- a/sources/multi.mangadex/Cargo.toml
+++ b/sources/multi.mangadex/Cargo.toml
@@ -9,6 +9,7 @@ serde = { version = "1.0.188", default-features = false, features = ["derive", "
 serde_json = { version = "1.0.105", default-features = false, features = ["alloc"] }
 chrono = { version = "0.4.30", default-features = false, features = ["alloc"] }
 hashbrown = "0.13.2"
+regex = { version = "1", default-features = false, features = ["unicode-perl"] }
 
 [dev-dependencies]
 aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", features = ["test"] }

--- a/sources/multi.mangadex/res/settings.json
+++ b/sources/multi.mangadex/res/settings.json
@@ -32,8 +32,8 @@
 			{
 				"type": "switch",
 				"key": "lockedChapters",
-				"title": "Shows Unavailable Chapters",
-				"subtitle": "Displays chapters that has been removed.",
+				"title": "Show Unavailable Chapters",
+				"subtitle": "Display chapters that has been removed",
 				"default": true,
 				"refreshes": ["content"]
 			},

--- a/sources/multi.mangadex/res/settings.json
+++ b/sources/multi.mangadex/res/settings.json
@@ -33,7 +33,7 @@
 				"type": "switch",
 				"key": "lockedChapters",
 				"title": "Shows Unavailable Chapters",
-				"subtitle": "Usually due to DMCA takedown requests, scanlator requests, or an official copyright claim",
+				"subtitle": "Displays chapters that has been removed.",
 				"default": true,
 				"refreshes": ["content"]
 			},

--- a/sources/multi.mangadex/res/settings.json
+++ b/sources/multi.mangadex/res/settings.json
@@ -30,6 +30,14 @@
 				"refreshes": ["content"]
 			},
 			{
+				"type": "switch",
+				"key": "lockedChapters",
+				"title": "Shows Unavailable Chapters",
+				"subtitle": "Usually due to DMCA takedown requests, scanlator requests, or an official copyright claim",
+				"default": true,
+				"refreshes": ["content"]
+			},
+			{
 				"type": "multi-select",
 				"key": "contentRating",
 				"title": "Default Content Rating",

--- a/sources/multi.mangadex/res/source.json
+++ b/sources/multi.mangadex/res/source.json
@@ -2,7 +2,7 @@
 	"info": {
 		"id": "multi.mangadex",
 		"name": "MangaDex",
-		"version": 10,
+		"version": 11,
 		"url": "https://mangadex.org",
 		"contentRating": 1,
 		"languages": [

--- a/sources/multi.mangadex/src/home.rs
+++ b/sources/multi.mangadex/src/home.rs
@@ -66,7 +66,7 @@ impl Home for MangaDex {
 		let owner_user_id = "d2ae45e0-b5e2-4e7f-a688-17925c2d7d6b";
 		let mut seasonal_res = Request::get(format!("{API_URL}/user/{owner_user_id}/list"))?.send()?;
 
-		let seasonal_re = Regex::new(r"^Seasonal:\s*(?P<season>Winter|Spring|Summer|Fall)\s*(?P<year>\d{4})$").expect("Failed to compile regex");
+		let seasonal_re = Regex::new(r"^Seasonal:\s*(?P<season>Winter|Spring|Summer|Fall)\s*(?P<year>\d{4})$").unwrap();
 		let season_to_rank = |season: &str| -> u8 {
 			match season.to_lowercase().as_str() {
 				"winter" => 1,
@@ -77,7 +77,7 @@ impl Home for MangaDex {
 			}
 		};
 		
-  		let mut latest_seasonal_lists = seasonal_res
+  		let mut current_seasonal_lists = seasonal_res
 			.get_json::<DexResponse<Vec<DexCustomList>>>()?
 			.data
 			.iter()
@@ -122,7 +122,7 @@ impl Home for MangaDex {
 					value: aidoku::HomeComponentValue::empty_scroller(),
 				});
 			}
-			for SeasonalList { name, .. } in latest_seasonal_lists.iter() {
+			for SeasonalList { name, .. } in current_seasonal_lists.iter() {
 				components.push(HomeComponent {
 					title: Some(name.clone()),
 					subtitle: None,
@@ -349,7 +349,7 @@ impl Home for MangaDex {
 
 		// same from a custom lists
 		{
-			let seasonal_list_responses = Request::send_all(latest_seasonal_lists.iter().map(|list| {
+			let seasonal_list_responses = Request::send_all(current_seasonal_lists.iter().map(|list| {
 				Request::get(format!(
 					"{API_URL}/manga\
 						?limit=100\
@@ -360,7 +360,7 @@ impl Home for MangaDex {
 				))
 				.unwrap()
 			}));
-			let latest_seasonal_lists = latest_seasonal_lists
+			let current_seasonal_lists = current_seasonal_lists
 				.iter_mut()
 				.zip(seasonal_list_responses)
 				.filter_map(|(list, res)| {
@@ -380,7 +380,7 @@ impl Home for MangaDex {
 				})
 				.collect::<Vec<(String, Vec<Link>)>>();
 
-			for (name, entries) in latest_seasonal_lists {
+			for (name, entries) in current_seasonal_lists {
 				send_partial_result(&HomePartialResult::Component(HomeComponent {
 					title: Some(name.clone()),
 					subtitle: None,

--- a/sources/multi.mangadex/src/home.rs
+++ b/sources/multi.mangadex/src/home.rs
@@ -59,14 +59,7 @@ impl Home for MangaDex {
 			.collect::<Vec<_>>();
 
 		// fetch seasonal list
-		struct SeasonalList<'a> {
-			name: String,
-			entries: Vec<&'a str>,
-		}
-		let owner_user_id = "d2ae45e0-b5e2-4e7f-a688-17925c2d7d6b";
-		let mut seasonal_res = Request::get(format!("{API_URL}/user/{owner_user_id}/list"))?.send()?;
-
-		let seasonal_re = Regex::new(r"^Seasonal:\s*(?P<season>Winter|Spring|Summer|Fall)\s*(?P<year>\d{4})$").unwrap();
+		let seasonal_regax = Regex::new(r"^Seasonal:\s*(?P<season>Winter|Spring|Summer|Fall)\s*(?P<year>\d{4})$").unwrap();
 		let season_to_rank = |season: &str| -> u8 {
 			match season.to_lowercase().as_str() {
 				"winter" => 1,
@@ -77,29 +70,33 @@ impl Home for MangaDex {
 			}
 		};
 		
-  		let mut current_seasonal_lists = seasonal_res
-			.get_json::<DexResponse<Vec<DexCustomList>>>()?
-			.data
-			.iter()
-			.filter_map(|item| {
-				let name = &item.attributes.name;
-				let captures = seasonal_re.captures(name)?;
-				let year = captures.name("year")?.as_str().parse::<u16>().ok();
-				let season_rank = season_to_rank(captures.name("season")?.as_str());
+		let owner_user_id = "d2ae45e0-b5e2-4e7f-a688-17925c2d7d6b";
+  		let mut seasonal_res = Request::get(format!("{API_URL}/user/{owner_user_id}/list"))?.send()?;
+    	if let Ok(response) = seasonal_res.get_json::<DexResponse<Vec<DexCustomList>>>() {
+			let current_seasonal_lists = response.data
+				.iter()
+				.filter_map(|item| {
+					let name = &item.attributes.name;
+					let captures = seasonal_regax.captures(name)?;
+					let year = captures.name("year")?.as_str().parse::<u16>().ok();
+					let season_rank = season_to_rank(captures.name("season")?.as_str());
 
-				let manga_ids = item.relationships.iter().filter_map(|relationship| {
-					if relationship.r#type == "manga" {
-						Some(relationship.id)
-					} else {
-						None
-					}
+					let manga_ids = item.relationships.iter().filter_map(|relationship| {
+						if relationship.r#type == "manga" {
+							Some(relationship.id)
+						} else {
+							None
+						}
+					})
+					.collect::<Vec<&str>>();
+
+					Some((year, season_rank, item.id, name, manga_ids))
 				})
-				.collect::<Vec<&str>>();
+				.max_by(|(y1, s1, _, _, _), (y2, s2, _, _, _)| (y1,s1).cmp(&(y2,s2)))
+				.map(|(_, _, id, name, manga_ids)| CustomList { id, name: name.clone(), entries: manga_ids });
 
-				Some((year, season_rank, name, manga_ids))
-			})
-			.max_by(|(y1, s1, _, _), (y2, s2, _, _)| (y1,s1).cmp(&(y2,s2)))
-			.map(|(_, _, name, manga_ids)| SeasonalList { name: name.clone(), entries: manga_ids });
+			custom_lists.extend(current_seasonal_lists);
+		};
 
 		// send basic home layout
 		{
@@ -120,13 +117,6 @@ impl Home for MangaDex {
 					title: Some(name.clone()),
 					subtitle: None,
 					value: aidoku::HomeComponentValue::empty_scroller(),
-				});
-			}
-			for SeasonalList { name, .. } in current_seasonal_lists.iter() {
-				components.push(HomeComponent {
-					title: Some(name.clone()),
-					subtitle: None,
-					value: aidoku::HomeComponentValue::empty_scroller()
 				});
 			}
 			components.push(HomeComponent {
@@ -302,7 +292,7 @@ impl Home for MangaDex {
 			let custom_list_responses = Request::send_all(custom_lists.iter().map(|list| {
 				Request::get(format!(
 					"{API_URL}/manga\
-						?limit=32\
+						?limit=100\
 						&includes[]=cover_art\
 						{content_ratings}\
 						&ids[]={}",
@@ -339,55 +329,6 @@ impl Home for MangaDex {
 						entries,
 						listing: Some(Listing {
 							id: format!("list-{id}"),
-							name,
-							kind: ListingKind::Default,
-						}),
-					},
-				}));
-			}
-		}
-
-		// same from a custom lists
-		{
-			let seasonal_list_responses = Request::send_all(current_seasonal_lists.iter().map(|list| {
-				Request::get(format!(
-					"{API_URL}/manga\
-						?limit=100\
-						&includes[]=cover_art\
-						{content_ratings}\
-						&ids[]={}",
-					list.entries.join("&ids[]=")
-				))
-				.unwrap()
-			}));
-			let current_seasonal_lists = current_seasonal_lists
-				.iter_mut()
-				.zip(seasonal_list_responses)
-				.filter_map(|(list, res)| {
-					Some((
-						list.name.clone(),
-						res.ok()?
-							.get_json::<DexResponse<Vec<DexManga>>>()
-							.map(|response| {
-								response
-									.data
-									.into_iter()
-									.map(|value| value.into_basic_manga().into())
-									.collect::<Vec<Link>>()
-							})
-							.ok()?,
-					))
-				})
-				.collect::<Vec<(String, Vec<Link>)>>();
-
-			for (name, entries) in current_seasonal_lists {
-				send_partial_result(&HomePartialResult::Component(HomeComponent {
-					title: Some(name.clone()),
-					subtitle: None,
-					value: aidoku::HomeComponentValue::Scroller {
-						entries,
-						listing: Some(Listing {
-							id: String::from("seasonal"),
 							name,
 							kind: ListingKind::Default,
 						}),

--- a/sources/multi.mangadex/src/lib.rs
+++ b/sources/multi.mangadex/src/lib.rs
@@ -221,6 +221,7 @@ impl Source for MangaDex {
 		if needs_chapters {
 			let languages = settings::get_languages_with_key("translatedLanguage")?;
 			let blocked_groups = settings::get_blocked_uuids()?;
+			let show_unavailable_chapters = settings::get_locked_chapters();
 
 			let url = format!(
 				"{API_URL}/manga/{}/feed\
@@ -231,11 +232,13 @@ impl Source for MangaDex {
 					&contentRating[]=erotica\
 					&contentRating[]=suggestive\
 					&contentRating[]=safe\
+					&includeUnavailable={}\
 					&includes[]=user\
 					&includes[]=scanlation_group\
 					{languages}\
 					{blocked_groups}",
-				manga.key
+				manga.key,
+				if show_unavailable_chapters { "1" } else { "0" }
 			);
 
 			let (mut chapters, total) = Request::get(&url)?

--- a/sources/multi.mangadex/src/models.rs
+++ b/sources/multi.mangadex/src/models.rs
@@ -140,6 +140,7 @@ pub struct DexChapterAttributes<'a> {
 	pub volume: Option<&'a str>,
 	pub chapter: Option<&'a str>,
 	pub external_url: Option<Value>,
+	pub is_unavailable: bool,
 	pub translated_language: &'a str,
 	pub publish_at: &'a str,
 }
@@ -400,6 +401,7 @@ impl From<DexChapter<'_>> for Chapter {
 			scanlators: Some(val.scanlators()),
 			url: Some(val.url()),
 			language: Some(String::from(val.attributes.translated_language)),
+			locked: val.attributes.is_unavailable,
 			..Default::default()
 		}
 	}

--- a/sources/multi.mangadex/src/models.rs
+++ b/sources/multi.mangadex/src/models.rs
@@ -112,6 +112,7 @@ pub struct DexCustomListAttributes {
 #[derive(Default, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", default)]
 pub struct DexCoverArtAttributes {
+	pub volume: Option<String>,
 	pub file_name: String,
 }
 

--- a/sources/multi.mangadex/src/settings.rs
+++ b/sources/multi.mangadex/src/settings.rs
@@ -16,6 +16,7 @@ const CONTENT_RATING_KEY: &str = "contentRating";
 const BLOCKED_UUIDS_KEY: &str = "blockedUUIDs";
 const FORCE_PORT_KEY: &str = "standardHttpsPort";
 const DATA_SAVER_KEY: &str = "dataSaver";
+const LOCKED_CHAPTERS_KEY: &str = "lockedChapters";
 const TOKEN_KEY: &str = "login";
 const CODE_VERIFIER_KEY: &str = "login.codeVerifier";
 
@@ -83,6 +84,10 @@ pub fn get_force_port() -> bool {
 
 pub fn get_data_saver() -> bool {
 	defaults_get::<bool>(DATA_SAVER_KEY).unwrap_or(false)
+}
+
+pub fn get_locked_chapters() -> bool {
+	defaults_get::<bool>(LOCKED_CHAPTERS_KEY).unwrap_or(false)
 }
 
 pub fn get_cover_quality() -> String {


### PR DESCRIPTION
Change:
- Adds show locked chapters which chapters are missing/unavailable.
- Adds current seasonal list with updated checks.
- Fixes wrong sort desending from alternative cover art.