### PR TITLE
fix(multi.mangafire): update vrf keys

### DIFF
--- a/sources/multi.mangafire/res/source.json
+++ b/sources/multi.mangafire/res/source.json
@@ -2,7 +2,7 @@
 	"info": {
 		"id": "multi.mangafire",
 		"name": "MangaFire",
-		"version": 3,
+		"version": 4,
 		"url": "https://mangafire.to",
 		"contentRating": 1,
 		"languages": ["en", "es", "es-419", "fr", "ja", "pt", "pt-BR"],

--- a/sources/multi.mangafire/src/home.rs
+++ b/sources/multi.mangafire/src/home.rs
@@ -1,13 +1,13 @@
-use crate::{MangaFire, BASE_URL};
+use crate::{BASE_URL, MangaFire};
 use aidoku::helpers::string::StripPrefixOrSelf;
 use aidoku::imports::html::Document;
+use aidoku::{Chapter, Link};
 use aidoku::{
-	alloc::{vec, Vec},
+	Home, HomeComponent, HomeLayout, HomePartialResult, Manga, MangaWithChapter, Result,
+	alloc::{Vec, vec},
 	imports::{net::Request, std::send_partial_result},
 	prelude::*,
-	Home, HomeComponent, HomeLayout, HomePartialResult, Manga, MangaWithChapter, Result,
 };
-use aidoku::{Chapter, Link};
 
 impl Home for MangaFire {
 	fn get_home(&self) -> Result<HomeLayout> {

--- a/sources/multi.mangafire/src/lib.rs
+++ b/sources/multi.mangafire/src/lib.rs
@@ -1,7 +1,9 @@
 #![no_std]
 use aidoku::{
-	alloc::{string::ToString, vec, String, Vec},
-	helpers::uri::{encode_uri_component, QueryParameters},
+	Chapter, ContentRating, DeepLinkHandler, DeepLinkResult, FilterValue, Listing, ListingProvider,
+	Manga, MangaPageResult, MangaStatus, Page, PageContent, Result, Source, Viewer,
+	alloc::{String, Vec, string::ToString, vec},
+	helpers::uri::{QueryParameters, encode_uri_component},
 	imports::{
 		error::AidokuError,
 		html::{Document, Html},
@@ -9,8 +11,6 @@ use aidoku::{
 		std::{current_date, parse_date, send_partial_result},
 	},
 	prelude::*,
-	Chapter, ContentRating, DeepLinkHandler, DeepLinkResult, FilterValue, Listing, ListingProvider,
-	Manga, MangaPageResult, MangaStatus, Page, PageContent, Result, Source, Viewer,
 };
 
 mod home;

--- a/sources/multi.mangafire/src/settings.rs
+++ b/sources/multi.mangafire/src/settings.rs
@@ -1,7 +1,7 @@
 use aidoku::{
+	Result,
 	alloc::{string::String, vec::Vec},
 	imports::{defaults::defaults_get, error::AidokuError},
-	Result,
 };
 
 // settings keys

--- a/sources/multi.mangafire/src/vrf.rs
+++ b/sources/multi.mangafire/src/vrf.rs
@@ -1,11 +1,11 @@
 // original script by @Trung0246 on github
-// based on https://github.com/keiyoushi/extensions-source/blob/main/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/VrfGenerator.kt
+// updated with keys from @podimium on discord
+// based on https://github.com/keiyoushi/extensions-source/blob/5a08b6078384a90ed23cc084d8bfc7b6f8397f07/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/VrfGenerator.kt
 use aidoku::{
 	alloc::{string::String, vec, vec::Vec},
 	helpers::uri::encode_uri_component,
-	HashMap,
 };
-use base64::{engine::general_purpose, Engine as _};
+use base64::{Engine, engine::general_purpose};
 
 pub struct VrfGenerator;
 
@@ -61,142 +61,148 @@ impl VrfGenerator {
 	}
 
 	pub fn generate(input: &str) -> String {
-		let rc4_keys: HashMap<&str, &str> = [
-			("l", "u8cBwTi1CM4XE3BkwG5Ble3AxWgnhKiXD9Cr279yNW0="),
-			("g", "t00NOJ/Fl3wZtez1xU6/YvcWDoXzjrDHJLL2r/IWgcY="),
-			("B", "S7I+968ZY4Fo3sLVNH/ExCNq7gjuOHjSRgSqh6SsPJc="),
-			("m", "7D4Q8i8dApRj6UWxXbIBEa1UqvjI+8W0UvPH9talJK8="),
-			("F", "0JsmfWZA1kwZeWLk5gfV5g41lwLL72wHbam5ZPfnOVE="),
-		]
-		.iter()
-		.cloned()
-		.collect();
+		let rc4_keys: [&str; 5] = [
+			// "u8cBwTi1CM4XE3BkwG5Ble3AxWgnhKiXD9Cr279yNW0=",
+			"FgxyJUQDPUGSzwbAq/ToWn4/e8jYzvabE+dLMb1XU1o=",
+			// "t00NOJ/Fl3wZtez1xU6/YvcWDoXzjrDHJLL2r/IWgcY=",
+			"CQx3CLwswJAnM1VxOqX+y+f3eUns03ulxv8Z+0gUyik=",
+			// "S7I+968ZY4Fo3sLVNH/ExCNq7gjuOHjSRgSqh6SsPJc=",
+			"fAS+otFLkKsKAJzu3yU+rGOlbbFVq+u+LaS6+s1eCJs=",
+			// "7D4Q8i8dApRj6UWxXbIBEa1UqvjI+8W0UvPH9talJK8=",
+			"Oy45fQVK9kq9019+VysXVlz1F9S1YwYKgXyzGlZrijo=",
+			// "0JsmfWZA1kwZeWLk5gfV5g41lwLL72wHbam5ZPfnOVE=",
+			"aoDIdXezm2l3HrcnQdkPJTDT8+W6mcl2/02ewBHfPzg=",
+		];
 
-		let seeds32: HashMap<&str, &str> = [
-			("A", "pGjzSCtS4izckNAOhrY5unJnO2E1VbrU+tXRYG24vTo="),
-			("V", "dFcKX9Qpu7mt/AD6mb1QF4w+KqHTKmdiqp7penubAKI="),
-			("N", "owp1QIY/kBiRWrRn9TLN2CdZsLeejzHhfJwdiQMjg3w="),
-			("P", "H1XbRvXOvZAhyyPaO68vgIUgdAHn68Y6mrwkpIpEue8="),
-			("k", "2Nmobf/mpQ7+Dxq1/olPSDj3xV8PZkPbKaucJvVckL0="),
-		]
-		.iter()
-		.cloned()
-		.collect();
+		let seeds32: [&str; 5] = [
+			// "pGjzSCtS4izckNAOhrY5unJnO2E1VbrU+tXRYG24vTo=",
+			"yH6MXnMEcDVWO/9a6P9W92BAh1eRLVFxFlWTHUqQ474=",
+			// "dFcKX9Qpu7mt/AD6mb1QF4w+KqHTKmdiqp7penubAKI=",
+			"RK7y4dZ0azs9Uqz+bbFB46Bx2K9EHg74ndxknY9uknA=",
+			// "owp1QIY/kBiRWrRn9TLN2CdZsLeejzHhfJwdiQMjg3w=",
+			"rqr9HeTQOg8TlFiIGZpJaxcvAaKHwMwrkqojJCpcvoc=",
+			// "H1XbRvXOvZAhyyPaO68vgIUgdAHn68Y6mrwkpIpEue8=",
+			"/4GPpmZXYpn5RpkP7FC/dt8SXz7W30nUZTe8wb+3xmU=",
+			// "2Nmobf/mpQ7+Dxq1/olPSDj3xV8PZkPbKaucJvVckL0=",
+			"wsSGSBXKWA9q1oDJpjtJddVxH+evCfL5SO9HZnUDFU8=",
+		];
 
-		let prefix_keys: HashMap<&str, &str> = [
-			("O", "Rowe+rg/0g=="),
-			("v", "8cULcnOMJVY8AA=="),
-			("L", "n2+Og2Gth8Hh"),
-			("p", "aRpvzH+yoA=="),
-			("W", "ZB4oBi0="),
-		]
-		.iter()
-		.cloned()
-		.collect();
+		let prefix_keys: [&str; 5] = [
+			// "Rowe+rg/0g==",
+			"l9PavRg=",
+			// "8cULcnOMJVY8AA==",
+			"Ml2v7ag1Jg==",
+			// "n2+Og2Gth8Hh",
+			"i/Va0UxrbMo=",
+			// "aRpvzH+yoA==",
+			"WFjKAHGEkQM=",
+			// "ZB4oBi0=",
+			"5Rr27rWd",
+		];
 
-		// Schedules
-		let schedule_c: [fn(u8) -> u8; 10] = [
-			|c| c.wrapping_sub(48),
-			|c| c.wrapping_sub(19),
-			|c| c ^ 241,
-			|c| c.wrapping_sub(19),
-			|c| c.wrapping_add(223),
-			|c| c.wrapping_sub(19),
-			|c| c.wrapping_sub(170),
-			|c| c.wrapping_sub(19),
-			|c| c.wrapping_sub(48),
-			|c| c ^ 8,
+		let schedule_0: [fn(u8) -> u8; 10] = [
+			|c| c.wrapping_sub(223),
+			|c| c.rotate_right(4),
+			|c| c.rotate_right(4),
+			|c| c.wrapping_add(234),
+			|c| c.rotate_right(7),
+			|c| c.rotate_right(2),
+			|c| c.rotate_right(7),
+			|c| c.wrapping_sub(223),
+			|c| c.rotate_right(7),
+			|c| c.rotate_right(6),
 		];
-		let schedule_y: [fn(u8) -> u8; 10] = [
-			|c| c.rotate_right(4),
-			|c| c.wrapping_add(223),
-			|c| c.rotate_right(4),
-			|c| c ^ 163,
-			|c| c.wrapping_sub(48),
-			|c| c.wrapping_add(82),
-			|c| c.wrapping_add(223),
-			|c| c.wrapping_sub(48),
-			|c| c ^ 83,
+		let schedule_1: [fn(u8) -> u8; 10] = [
+			|c| c.wrapping_add(19),
+			|c| c.rotate_right(7),
+			|c| c.wrapping_add(19),
+			|c| c.rotate_right(6),
+			|c| c.wrapping_add(19),
+			|c| c.rotate_right(1),
+			|c| c.wrapping_add(19),
+			|c| c.rotate_right(6),
+			|c| c.rotate_right(7),
 			|c| c.rotate_right(4),
 		];
-		let schedule_b: [fn(u8) -> u8; 10] = [
-			|c| c.wrapping_sub(19),
-			|c| c.wrapping_add(82),
-			|c| c.wrapping_sub(48),
-			|c| c.wrapping_sub(170),
-			|c| c.rotate_right(4),
-			|c| c.wrapping_sub(48),
-			|c| c.wrapping_sub(170),
-			|c| c ^ 8,
-			|c| c.wrapping_add(82),
-			|c| c ^ 163,
+		let schedule_2: [fn(u8) -> u8; 10] = [
+			|c| c.wrapping_sub(223),
+			|c| c.rotate_right(1),
+			|c| c.wrapping_add(19),
+			|c| c.wrapping_sub(223),
+			|c| c.rotate_left(2),
+			|c| c.wrapping_sub(223),
+			|c| c.wrapping_add(19),
+			|c| c.rotate_left(1),
+			|c| c.rotate_left(2),
+			|c| c.rotate_left(1),
 		];
-		let schedule_j: [fn(u8) -> u8; 10] = [
-			|c| c.wrapping_add(223),
-			|c| c.rotate_right(4),
-			|c| c.wrapping_add(223),
-			|c| c ^ 83,
-			|c| c.wrapping_sub(19),
-			|c| c.wrapping_add(223),
-			|c| c.wrapping_sub(170),
-			|c| c.wrapping_add(223),
-			|c| c.wrapping_sub(170),
-			|c| c ^ 83,
+		let schedule_3: [fn(u8) -> u8; 10] = [
+			|c| c.wrapping_add(19),
+			|c| c.rotate_left(1),
+			|c| c.rotate_left(1),
+			|c| c.rotate_right(1),
+			|c| c.wrapping_add(234),
+			|c| c.rotate_left(1),
+			|c| c.wrapping_sub(223),
+			|c| c.rotate_left(6),
+			|c| c.rotate_left(4),
+			|c| c.rotate_left(1),
 		];
-		let schedule_e: [fn(u8) -> u8; 10] = [
-			|c| c.wrapping_add(82),
-			|c| c ^ 83,
-			|c| c ^ 163,
-			|c| c.wrapping_add(82),
-			|c| c.wrapping_sub(170),
-			|c| c ^ 8,
-			|c| c ^ 241,
-			|c| c.wrapping_add(82),
-			|c| c.wrapping_add(176),
+		let schedule_4: [fn(u8) -> u8; 10] = [
+			|c| c.rotate_right(1),
+			|c| c.rotate_left(1),
+			|c| c.rotate_left(6),
+			|c| c.rotate_right(1),
+			|c| c.rotate_left(2),
 			|c| c.rotate_right(4),
+			|c| c.rotate_left(1),
+			|c| c.rotate_left(1),
+			|c| c.wrapping_sub(223),
+			|c| c.rotate_left(2),
 		];
 
 		let input = encode_uri_component(input);
 		let mut bytes = input.as_bytes().to_vec();
-		bytes = Self::rc4(&Self::atob(rc4_keys["l"]), &bytes);
+
+		bytes = Self::rc4(&Self::atob(rc4_keys[0]), &bytes);
 		bytes = Self::transform(
 			&bytes,
-			&Self::atob(seeds32["A"]),
-			&Self::atob(prefix_keys["O"]),
-			7,
-			&schedule_c,
+			&Self::atob(seeds32[0]),
+			&Self::atob(prefix_keys[0]),
+			Self::atob(prefix_keys[0]).len(),
+			&schedule_0,
 		);
-		bytes = Self::rc4(&Self::atob(rc4_keys["g"]), &bytes);
+		bytes = Self::rc4(&Self::atob(rc4_keys[1]), &bytes);
 		bytes = Self::transform(
 			&bytes,
-			&Self::atob(seeds32["V"]),
-			&Self::atob(prefix_keys["v"]),
-			10,
-			&schedule_y,
+			&Self::atob(seeds32[1]),
+			&Self::atob(prefix_keys[1]),
+			Self::atob(prefix_keys[1]).len(),
+			&schedule_1,
 		);
-		bytes = Self::rc4(&Self::atob(rc4_keys["B"]), &bytes);
+		bytes = Self::rc4(&Self::atob(rc4_keys[2]), &bytes);
 		bytes = Self::transform(
 			&bytes,
-			&Self::atob(seeds32["N"]),
-			&Self::atob(prefix_keys["L"]),
-			9,
-			&schedule_b,
+			&Self::atob(seeds32[2]),
+			&Self::atob(prefix_keys[2]),
+			Self::atob(prefix_keys[2]).len(),
+			&schedule_2,
 		);
-		bytes = Self::rc4(&Self::atob(rc4_keys["m"]), &bytes);
+		bytes = Self::rc4(&Self::atob(rc4_keys[3]), &bytes);
 		bytes = Self::transform(
 			&bytes,
-			&Self::atob(seeds32["P"]),
-			&Self::atob(prefix_keys["p"]),
-			7,
-			&schedule_j,
+			&Self::atob(seeds32[3]),
+			&Self::atob(prefix_keys[3]),
+			Self::atob(prefix_keys[3]).len(),
+			&schedule_3,
 		);
-		bytes = Self::rc4(&Self::atob(rc4_keys["F"]), &bytes);
+		bytes = Self::rc4(&Self::atob(rc4_keys[4]), &bytes);
 		bytes = Self::transform(
 			&bytes,
-			&Self::atob(seeds32["k"]),
-			&Self::atob(prefix_keys["W"]),
-			5,
-			&schedule_e,
+			&Self::atob(seeds32[4]),
+			&Self::atob(prefix_keys[4]),
+			Self::atob(prefix_keys[4]).len(),
+			&schedule_4,
 		);
 
 		let mut encoded = Self::btoa(&bytes);
@@ -214,9 +220,12 @@ mod test {
 	fn test_vrf() {
 		assert_eq!(
 			VrfGenerator::generate("67890@ The quick brown fox jumps over the lazy dog @12345"),
-			"ZBYeRCjYBk0tkZnKW4kTuWBYw-81e-csvu6v17UY4zchviixt67VJ\
-			 _tjpFEsOXB-a8X4ZFpDoDbPq8ms-7IyN95vmLVdP5vWSoTAl4ZbIB\
-			 E8xijci8emrkdEYmArOPMUq5KAc3KEabUzHkNwjBtwvs0fQR7nDpI"
+			// "ZBYeRCjYBk0tkZnKW4kTuWBYw-81e-csvu6v17UY4zchviixt67VJ\
+			//  _tjpFEsOXB-a8X4ZFpDoDbPq8ms-7IyN95vmLVdP5vWSoTAl4ZbIB\
+			//  E8xijci8emrkdEYmArOPMUq5KAc3KEabUzHkNwjBtwvs0fQR7nDpI"
+			"5fcaUfZo7rW1-Z3vTEvXO5sJBfP2zuTM2NIVmftpuGhYgy8c-Yl92\
+			 uQOuxzYksgVMUWKu7h-Pt5_6c0KZ2c1BpRQwVCIkRycge1pensQ__\
+			 YViJZddxqB5PvElml6UdQ1h4w8kCFftPUYNoSHTqNBX0HfFg"
 		)
 	}
 }


### PR DESCRIPTION
closes #181 

this is only a temporary fix, since it seems that the source might rotate keys and schedules at least monthly. aidoku-rs doesn't appear to have the same capabilities that keiyoushi has regarding web view request intercepting, so I am unsure what a good permanent solution would be.