### PR TITLE
fix(en.mangago): missing pages in some chapters

### DIFF
--- a/sources/en.mangago/res/source.json
+++ b/sources/en.mangago/res/source.json
@@ -2,7 +2,7 @@
 	"info": {
 		"id": "en.mangago",
 		"name": "Mangago",
-		"version": 2,
+		"version": 3,
 		"url": "https://www.mangago.me",
 		"contentRating": 2,
 		"languages": ["en"]

--- a/sources/en.mangago/src/lib.rs
+++ b/sources/en.mangago/src/lib.rs
@@ -23,6 +23,7 @@ mod crypto;
 mod helpers;
 
 const BASE_URL: &str = "https://www.mangago.me";
+const DESKTOP_USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36";
 
 struct Mangago;
 
@@ -252,7 +253,10 @@ impl Source for Mangago {
 	fn get_page_list(&self, _manga: Manga, chapter: Chapter) -> Result<Vec<Page>> {
 		let url = format!("{BASE_URL}{}", chapter.key);
 		// https://github.com/keiyoushi/extensions-source/blob/14d648256ec3d2c123da49d619df45fd25c86f36/src/en/mangago/src/eu/kanade/tachiyomi/extension/en/mangago/Mangago.kt#L86
-		let html = Request::get(url)?.header("Cookie", "_m_superu=1").html()?;
+		let html = Request::get(url)?
+			.header("User-Agent", DESKTOP_USER_AGENT)
+			.header("Cookie", "_m_superu=1")
+			.html()?;
 
 		let imgsrcs_script = html
 			.select("script")


### PR DESCRIPTION
apparently the `imgsrcs` variable doesn't contain the entire set of pages on the mobile site.

closes #379