### PR TITLE
fix(en.asurascans): load premium chapters with auth

### DIFF
--- a/sources/en.asurascans/res/source.json
+++ b/sources/en.asurascans/res/source.json
@@ -2,7 +2,7 @@
 	"info": {
 		"id": "en.asurascans",
 		"name": "Asura Scans",
-		"version": 14,
+		"version": 15,
 		"url": "https://asurascans.com",
 		"contentRating": 0,
 		"languages": ["en"],

--- a/sources/en.asurascans/src/auth.rs
+++ b/sources/en.asurascans/src/auth.rs
@@ -35,14 +35,23 @@ pub fn logout() {
 }
 
 pub fn get_access_token() -> Result<String> {
+	Ok(get_login_status()?.access_token)
+}
+
+pub fn get_login_status() -> Result<LoginStatus> {
 	let old_status = defaults_get::<LoginStatus>(AUTH_KEY).ok_or(error!("Not logged in"))?;
 	let status = refresh(&old_status.refresh_token)?;
-	Ok(status.access_token)
+	defaults_set_data(AUTH_KEY, status.clone());
+	Ok(status)
 }
 
 fn refresh(refresh_token: &str) -> Result<LoginStatus> {
-	let res: RefreshResponse = Request::post(format!("{API_URL}/auth/refresh"))?
+	let mut res: RefreshResponse = Request::post(format!("{API_URL}/auth/refresh"))?
+		.header("Content-Type", "application/json")
 		.body(format!("{{\"refresh_token\":\"{refresh_token}\"}}"))
 		.json_owned()?;
+	if res.data.refresh_token.is_none() {
+		res.data.refresh_token = Some(refresh_token.into());
+	}
 	Ok(LoginStatus::from(res))
 }

--- a/sources/en.asurascans/src/lib.rs
+++ b/sources/en.asurascans/src/lib.rs
@@ -247,24 +247,24 @@ impl Source for AsuraScans {
 				),
 			);
 		}
-		if let Ok(json) = api_req.json_owned::<serde_json::Value>() {
-			if let Some(page_arr) = json["data"]["chapter"]["pages"].as_array() {
-				let pages: Vec<Page> = page_arr
-					.iter()
-					.filter_map(|obj| {
-						let url = obj
-							.as_str()
-							.or_else(|| obj["url"].as_str())
-							.or_else(|| obj["url"][1].as_str())?;
-						Some(Page {
-							content: PageContent::url(url),
-							..Default::default()
-						})
+		if let Ok(json) = api_req.json_owned::<serde_json::Value>()
+			&& let Some(page_arr) = json["data"]["chapter"]["pages"].as_array()
+		{
+			let pages: Vec<Page> = page_arr
+				.iter()
+				.filter_map(|obj| {
+					let url = obj
+						.as_str()
+						.or_else(|| obj["url"].as_str())
+						.or_else(|| obj["url"][1].as_str())?;
+					Some(Page {
+						content: PageContent::url(url),
+						..Default::default()
 					})
-					.collect();
-				if !pages.is_empty() {
-					return Ok(pages);
-				}
+				})
+				.collect();
+			if !pages.is_empty() {
+				return Ok(pages);
 			}
 		}
 

--- a/sources/en.asurascans/src/lib.rs
+++ b/sources/en.asurascans/src/lib.rs
@@ -235,14 +235,50 @@ impl Source for AsuraScans {
 	}
 
 	fn get_page_list(&self, manga: Manga, chapter: Chapter) -> Result<Vec<Page>> {
+		let api_url = format!("{API_URL}/series/{}/chapters/{}", manga.key, chapter.key);
+		let mut api_req = Request::get(api_url)?;
+		if let Ok(status) = auth::get_login_status() {
+			api_req.set_header("Authorization", &format!("Bearer {}", status.access_token));
+			api_req.set_header(
+				"Cookie",
+				&format!(
+					"access_token={}; refresh_token={}",
+					status.access_token, status.refresh_token
+				),
+			);
+		}
+		if let Ok(json) = api_req.json_owned::<serde_json::Value>() {
+			if let Some(page_arr) = json["data"]["chapter"]["pages"].as_array() {
+				let pages: Vec<Page> = page_arr
+					.iter()
+					.filter_map(|obj| {
+						let url = obj
+							.as_str()
+							.or_else(|| obj["url"].as_str())
+							.or_else(|| obj["url"][1].as_str())?;
+						Some(Page {
+							content: PageContent::url(url),
+							..Default::default()
+						})
+					})
+					.collect();
+				if !pages.is_empty() {
+					return Ok(pages);
+				}
+			}
+		}
+
 		let url = helpers::get_chapter_url(&chapter.key, &manga.key);
 		let mut req = Request::get(url)?;
-		if auth::is_subscribed() {
-			// untested
-			if let Ok(token) = auth::get_access_token() {
-				req.set_header("Authorization", &format!("Bearer {token}"));
-				req.set_header("Cookie", &format!("access_token={token}"));
-			}
+		if let Ok(status) = auth::get_login_status() {
+			req.set_header("Authorization", &format!("Bearer {}", status.access_token));
+			req.set_header(
+				"Cookie",
+				&format!(
+					"access_token={}; refresh_token={}",
+					status.access_token, status.refresh_token
+				),
+			);
 		}
 		let html = req.html()?;
 

--- a/sources/en.asurascans/src/models.rs
+++ b/sources/en.asurascans/src/models.rs
@@ -1,10 +1,11 @@
 use aidoku::{
 	Manga,
 	alloc::{string::String, vec::Vec},
+	imports::std::{current_date, parse_date},
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct LoginStatus {
 	pub access_token: String,
 	pub refresh_token: String,
@@ -13,10 +14,20 @@ pub struct LoginStatus {
 
 impl From<RefreshResponse> for LoginStatus {
 	fn from(value: RefreshResponse) -> Self {
+		let is_subscribed = value
+			.data
+			.subscription_status
+			.as_ref()
+			.is_some_and(|status| status.has_subscription.unwrap_or_default())
+			|| value
+				.data
+				.user
+				.as_ref()
+				.is_some_and(|user| user.has_active_subscription());
 		Self {
 			access_token: value.data.access_token,
-			refresh_token: value.data.refresh_token,
-			is_subscribed: value.data.subscription_status.has_subscription,
+			refresh_token: value.data.refresh_token.unwrap_or_default(),
+			is_subscribed,
 		}
 	}
 }
@@ -29,13 +40,33 @@ pub struct RefreshResponse {
 #[derive(Deserialize)]
 pub struct RefreshResponseData {
 	pub access_token: String,
-	pub refresh_token: String,
-	pub subscription_status: RefreshSubscriptionStatus,
+	pub refresh_token: Option<String>,
+	pub subscription_status: Option<RefreshSubscriptionStatus>,
+	pub user: Option<AuthUser>,
 }
 
 #[derive(Deserialize)]
 pub struct RefreshSubscriptionStatus {
-	pub has_subscription: bool,
+	pub has_subscription: Option<bool>,
+}
+
+#[derive(Deserialize)]
+pub struct AuthUser {
+	role: Option<String>,
+	premium_until: Option<String>,
+}
+
+impl AuthUser {
+	fn has_active_subscription(&self) -> bool {
+		let role = self.role.as_deref().unwrap_or("user");
+		matches!(role, "staff" | "moderator" | "uploader" | "admin")
+			|| matches!(role, "basic" | "premium")
+				&& self
+					.premium_until
+					.as_deref()
+					.and_then(|date| parse_date(date, "yyyy-MM-dd'T'HH:mm:ss'Z'"))
+					.is_some_and(|date| date > current_date())
+	}
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
## Summary
- send JSON content type when refreshing Asura auth tokens
- preserve refreshed login status, including rotated tokens
- load chapter pages through Asura's authenticated chapter API before falling back to HTML props
- bump en.asurascans to v15

## Testing
- cargo +stable-x86_64-pc-windows-gnu fmt
- cargo +stable-x86_64-pc-windows-gnu build --release
- manually verified premium chapter API returns pages when authenticated
- manually tested logged out and non premium user still show locked chapter and are able to load normal ones