### PR TITLE
fix(en.comix): handle scrambled page images

### DIFF
--- a/sources/en.comix/Cargo.lock
+++ b/sources/en.comix/Cargo.lock
@@ -62,6 +62,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,6 +94,7 @@ version = "0.1.0"
 dependencies = [
  "aidoku",
  "aidoku-test",
+ "base64",
  "regex",
  "serde",
  "serde_json",

--- a/sources/en.comix/Cargo.lock
+++ b/sources/en.comix/Cargo.lock
@@ -88,6 +88,7 @@ version = "0.1.0"
 dependencies = [
  "aidoku",
  "aidoku-test",
+ "regex",
  "serde",
  "serde_json",
 ]
@@ -232,6 +233,31 @@ checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustc_version"

--- a/sources/en.comix/Cargo.toml
+++ b/sources/en.comix/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib"]
 aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", features = ["json"] }
 serde = { version = "1.0", features = ["derive", "alloc"], default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+regex = { version = "1.12.3", default-features = false }
 
 [dev-dependencies]
 aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", features = ["test"] }

--- a/sources/en.comix/Cargo.toml
+++ b/sources/en.comix/Cargo.toml
@@ -10,8 +10,8 @@ crate-type = ["cdylib"]
 aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", features = ["json"] }
 serde = { version = "1.0", features = ["derive", "alloc"], default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
-regex = { version = "1.12.3", default-features = false }
-base64 = { version = "0.22.1", default-features = false, features = ["alloc"] }
+regex = { version = "1.12", default-features = false }
+base64 = { version = "0.22", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", features = ["test"] }

--- a/sources/en.comix/Cargo.toml
+++ b/sources/en.comix/Cargo.toml
@@ -11,6 +11,7 @@ aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", features = ["json"] 
 serde = { version = "1.0", features = ["derive", "alloc"], default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 regex = { version = "1.12.3", default-features = false }
+base64 = { version = "0.22.1", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", features = ["test"] }

--- a/sources/en.comix/res/source.json
+++ b/sources/en.comix/res/source.json
@@ -2,7 +2,7 @@
 	"info": {
 		"id": "en.comix",
 		"name": "Comix",
-		"version": 15,
+		"version": 16,
 		"url": "https://comix.to",
 		"contentRating": 1,
 		"languages": ["en"]

--- a/sources/en.comix/src/lib.rs
+++ b/sources/en.comix/src/lib.rs
@@ -285,7 +285,13 @@ impl Source for Comix {
 					format!("{base_url}/{}", page.url.trim_start_matches('/'))
 				};
 				Page {
-					content: PageContent::url(url),
+					content: if let Some(s) = page.s {
+						let mut context = PageContext::new();
+						context.insert("s".into(), s.to_string());
+						PageContent::url_context(url, context)
+					} else {
+						PageContent::url(url)
+					},
 					..Default::default()
 				}
 			})
@@ -501,57 +507,31 @@ impl PageImageProcessor for Comix {
 	fn process_page_image(
 		&self,
 		response: ImageResponse,
-		_context: Option<PageContext>,
+		context: Option<PageContext>,
 	) -> Result<ImageRef> {
-		let Some(url) = response.request.url else {
-			bail!("Unable to get the image url")
-		};
+		if context.is_some_and(|ctx| ctx.get("s").is_some_and(|s| s == "1")) {
+			let Some(url) = response.request.url else {
+				bail!("Unable to get the image url")
+			};
 
-		let mut is_scrambled = false;
+			let web_view = web::create_web_view()?;
+			let data_url = web::descramble_image(
+				&web_view,
+				response.image.width(),
+				response.image.height(),
+				url.as_ref(),
+			)?;
+			let Some((_, base64_data)) = data_url.split_once(',') else {
+				bail!("Unable to get the raw image data")
+			};
+			let bytes: Vec<u8> = general_purpose::STANDARD
+				.decode(base64_data)
+				.or_else(|_| bail!("Invalid base64 data given"))?;
 
-		if !response.headers.contains_key("x-scramble-grid")
-			|| !response.headers.contains_key("x-scramble-seed")
-		{
-			// There is a bug with the current response header that can be empty when there should be something.
-			// This might not be needed in the future but for now, we need it to ensure correct response header.
-			let image_response = Request::head(&url)?.send()?;
-			if image_response.get_header("x-scramble-grid").is_some()
-				&& image_response
-					.get_header("x-scramble-seed")
-					.is_some_and(|seed| seed != "0")
-			{
-				is_scrambled = true;
-			}
+			Ok(ImageRef::new(bytes.as_ref()))
 		} else {
-			// If both exists, we can check if the seed is scrambled or not.
-			if response
-				.headers
-				.get("x-scramble-seed")
-				.is_some_and(|seed| seed != "0")
-			{
-				is_scrambled = true;
-			}
+			Ok(response.image)
 		}
-
-		if !is_scrambled {
-			return Ok(response.image);
-		}
-
-		let web_view = web::create_web_view()?;
-		let data_url = web::descramble_image(
-			&web_view,
-			response.image.width(),
-			response.image.height(),
-			url.as_ref(),
-		)?;
-		let Some((_, base64_data)) = data_url.split_once(',') else {
-			bail!("Unable to get the raw image data")
-		};
-		let bytes: Vec<u8> = general_purpose::STANDARD
-			.decode(base64_data)
-			.or_else(|_| bail!("Invalid base64 data given"))?;
-
-		Ok(ImageRef::new(bytes.as_ref()))
 	}
 }
 

--- a/sources/en.comix/src/lib.rs
+++ b/sources/en.comix/src/lib.rs
@@ -288,6 +288,8 @@ impl Source for Comix {
 					content: if let Some(s) = page.s {
 						let mut context = PageContext::new();
 						context.insert("s".into(), s.to_string());
+						context.insert("width".into(), page.width.to_string());
+						context.insert("height".into(), page.height.to_string());
 						PageContent::url_context(url, context)
 					} else {
 						PageContent::url(url)
@@ -509,26 +511,34 @@ impl PageImageProcessor for Comix {
 		response: ImageResponse,
 		context: Option<PageContext>,
 	) -> Result<ImageRef> {
-		if context.is_some_and(|ctx| ctx.get("s").is_some_and(|s| s == "1")) {
-			let Some(url) = response.request.url else {
-				bail!("Unable to get the image url")
-			};
+		if let Some(context) = context {
+			if context.get("s").is_some_and(|s| s == "1") {
+				let Some(url) = response.request.url else {
+					bail!("Unable to get the image url")
+				};
 
-			let web_view = web::create_web_view()?;
-			let data_url = web::descramble_image(
-				&web_view,
-				response.image.width(),
-				response.image.height(),
-				url.as_ref(),
-			)?;
-			let Some((_, base64_data)) = data_url.split_once(',') else {
-				bail!("Unable to get the raw image data")
-			};
-			let bytes: Vec<u8> = general_purpose::STANDARD
-				.decode(base64_data)
-				.or_else(|_| bail!("Invalid base64 data given"))?;
+				let Some(width) = context.get("width").and_then(|s| s.parse::<f32>().ok()) else {
+					bail!("Unable to get the image width")
+				};
 
-			Ok(ImageRef::new(bytes.as_ref()))
+				let Some(height) = context.get("height").and_then(|s| s.parse::<f32>().ok()) else {
+					bail!("Unable to get the image height")
+				};
+
+				let web_view = web::create_web_view()?;
+
+				let data_url = web::descramble_image(&web_view, width, height, url.as_ref())?;
+				let Some((_, base64_data)) = data_url.split_once(',') else {
+					bail!("Unable to get the raw image data")
+				};
+				let bytes: Vec<u8> = general_purpose::STANDARD
+					.decode(base64_data)
+					.or_else(|_| bail!("Invalid base64 data given"))?;
+
+				Ok(ImageRef::new(bytes.as_ref()))
+			} else {
+				Ok(response.image)
+			}
 		} else {
 			Ok(response.image)
 		}

--- a/sources/en.comix/src/lib.rs
+++ b/sources/en.comix/src/lib.rs
@@ -241,15 +241,9 @@ impl Source for Comix {
 			}
 
 			let mut chapters: Vec<Chapter> = if deduplicate {
-				chapter_map
-					.into_values()
-					.map(|item| item.into_chapter())
-					.collect()
+				chapter_map.into_values().map(Into::into).collect()
 			} else {
-				chapter_list
-					.into_iter()
-					.map(|item| item.into_chapter())
-					.collect()
+				chapter_list.into_iter().map(Into::into).collect()
 			};
 
 			if deduplicate {
@@ -510,14 +504,21 @@ impl PageImageProcessor for Comix {
 		_context: Option<PageContext>,
 	) -> Result<ImageRef> {
 		let web_view = web::create_web_view()?;
+		let Some(url) = response.request.url else {
+			bail!("Unable to get the image url")
+		};
 		let data_url = web::descramble_image(
 			&web_view,
 			response.image.width(),
 			response.image.height(),
-			response.request.url.unwrap().as_ref(),
+			url.as_ref(),
 		)?;
-		let base64_data = data_url.split_once(',').map(|(_, data)| data).unwrap();
-		let bytes: Vec<u8> = general_purpose::STANDARD.decode(base64_data).unwrap();
+		let Some((_, base64_data)) = data_url.split_once(',') else {
+			bail!("Unable to get the raw image data")
+		};
+		let bytes: Vec<u8> = general_purpose::STANDARD
+			.decode(base64_data)
+			.or_else(|_| bail!("Invalid base64 data given"))?;
 
 		Ok(ImageRef::new(bytes.as_ref()))
 	}

--- a/sources/en.comix/src/lib.rs
+++ b/sources/en.comix/src/lib.rs
@@ -1,10 +1,11 @@
 #![no_std]
 
+use aidoku::imports::canvas::ImageRef;
 use aidoku::{
 	Chapter, DeepLinkHandler, DeepLinkResult, FilterValue, HashMap, Home, HomeComponent,
-	HomeLayout, HomePartialResult, ImageRequestProvider, Link, LinkValue, Listing, ListingProvider,
-	Manga, MangaPageResult, MangaWithChapter, NotificationHandler, Page, PageContent, PageContext,
-	Result, Source,
+	HomeLayout, HomePartialResult, ImageRequestProvider, ImageResponse, Link, LinkValue, Listing,
+	ListingProvider, Manga, MangaPageResult, MangaWithChapter, NotificationHandler, Page,
+	PageContent, PageContext, PageImageProcessor, Result, Source,
 	alloc::{String, Vec, string::ToString, vec},
 	helpers::uri::{QueryParameters, encode_uri_component},
 	imports::{
@@ -13,6 +14,7 @@ use aidoku::{
 	},
 	prelude::*,
 };
+use base64::{Engine, engine::general_purpose};
 
 mod helpers;
 mod models;
@@ -497,12 +499,27 @@ impl ListingProvider for Comix {
 
 impl ImageRequestProvider for Comix {
 	fn get_image_request(&self, url: String, _context: Option<PageContext>) -> Result<Request> {
-		let request = Request::get(url.replace("/si/", "/i/").replace("/sii/", "/i/"));
-		if request.is_err() {
-			Ok(Request::get(url)?.header("Referer", &format!("{BASE_URL}/")))
-		} else {
-			Ok(request?.header("Referer", &format!("{BASE_URL}/")))
-		}
+		Ok(Request::get(url)?.header("Referer", &format!("{BASE_URL}/")))
+	}
+}
+
+impl PageImageProcessor for Comix {
+	fn process_page_image(
+		&self,
+		response: ImageResponse,
+		_context: Option<PageContext>,
+	) -> Result<ImageRef> {
+		let web_view = web::create_web_view()?;
+		let data_url = web::descramble_image(
+			&web_view,
+			response.image.width(),
+			response.image.height(),
+			response.request.url.unwrap().as_ref(),
+		)?;
+		let base64_data = data_url.split_once(',').map(|(_, data)| data).unwrap();
+		let bytes: Vec<u8> = general_purpose::STANDARD.decode(base64_data).unwrap();
+
+		Ok(ImageRef::new(bytes.as_ref()))
 	}
 }
 
@@ -552,6 +569,7 @@ register_source!(
 	Home,
 	ListingProvider,
 	ImageRequestProvider,
+	PageImageProcessor,
 	NotificationHandler,
 	DeepLinkHandler
 );

--- a/sources/en.comix/src/lib.rs
+++ b/sources/en.comix/src/lib.rs
@@ -503,10 +503,41 @@ impl PageImageProcessor for Comix {
 		response: ImageResponse,
 		_context: Option<PageContext>,
 	) -> Result<ImageRef> {
-		let web_view = web::create_web_view()?;
 		let Some(url) = response.request.url else {
 			bail!("Unable to get the image url")
 		};
+
+		let mut is_scrambled = false;
+
+		if !response.headers.contains_key("x-scramble-grid")
+			|| !response.headers.contains_key("x-scramble-seed")
+		{
+			// There is a bug with the current response header that can be empty when there should be something.
+			// This might not be needed in the future but for now, we need it to ensure correct response header.
+			let image_response = Request::head(&url)?.send()?;
+			if image_response.get_header("x-scramble-grid").is_some()
+				&& image_response
+					.get_header("x-scramble-seed")
+					.is_some_and(|seed| seed != "0")
+			{
+				is_scrambled = true;
+			}
+		} else {
+			// If both exists, we can check if the seed is scrambled or not.
+			if response
+				.headers
+				.get("x-scramble-seed")
+				.is_some_and(|seed| seed != "0")
+			{
+				is_scrambled = true;
+			}
+		}
+
+		if !is_scrambled {
+			return Ok(response.image);
+		}
+
+		let web_view = web::create_web_view()?;
 		let data_url = web::descramble_image(
 			&web_view,
 			response.image.width(),

--- a/sources/en.comix/src/lib.rs
+++ b/sources/en.comix/src/lib.rs
@@ -1,9 +1,10 @@
 #![no_std]
+
 use aidoku::{
 	Chapter, DeepLinkHandler, DeepLinkResult, FilterValue, HashMap, Home, HomeComponent,
 	HomeLayout, HomePartialResult, ImageRequestProvider, Link, LinkValue, Listing, ListingProvider,
-	Manga, MangaPageResult, MangaWithChapter, NotificationHandler, Page, PageContent, Result,
-	Source,
+	Manga, MangaPageResult, MangaWithChapter, NotificationHandler, Page, PageContent, PageContext,
+	Result, Source,
 	alloc::{String, Vec, string::ToString, vec},
 	helpers::uri::{QueryParameters, encode_uri_component},
 	imports::{
@@ -288,7 +289,7 @@ impl Source for Comix {
 					format!("{base_url}/{}", page.url.trim_start_matches('/'))
 				};
 				Page {
-					content: PageContent::url(url.replace("/si/", "/i/")),
+					content: PageContent::url(url),
 					..Default::default()
 				}
 			})
@@ -495,12 +496,13 @@ impl ListingProvider for Comix {
 }
 
 impl ImageRequestProvider for Comix {
-	fn get_image_request(
-		&self,
-		url: String,
-		_context: Option<aidoku::PageContext>,
-	) -> Result<Request> {
-		Ok(Request::get(url)?.header("Referer", &format!("{BASE_URL}/")))
+	fn get_image_request(&self, url: String, _context: Option<PageContext>) -> Result<Request> {
+		let request = Request::get(url.replace("/si/", "/i/").replace("/sii/", "/i/"));
+		if request.is_err() {
+			Ok(Request::get(url)?.header("Referer", &format!("{BASE_URL}/")))
+		} else {
+			Ok(request?.header("Referer", &format!("{BASE_URL}/")))
+		}
 	}
 }
 

--- a/sources/en.comix/src/lib.rs
+++ b/sources/en.comix/src/lib.rs
@@ -243,12 +243,12 @@ impl Source for Comix {
 			let mut chapters: Vec<Chapter> = if deduplicate {
 				chapter_map
 					.into_values()
-					.map(|item| item.into_chapter(&manga.key))
+					.map(|item| item.into_chapter())
 					.collect()
 			} else {
 				chapter_list
 					.into_iter()
-					.map(|item| item.into_chapter(&manga.key))
+					.map(|item| item.into_chapter())
 					.collect()
 			};
 

--- a/sources/en.comix/src/models.rs
+++ b/sources/en.comix/src/models.rs
@@ -247,22 +247,24 @@ impl ComixChapter {
 	pub fn created_at(&self) -> i64 {
 		helpers::parse_relative_date_string(&self.created_at_formatted)
 	}
+}
 
-	pub fn into_chapter(self) -> Chapter {
-		let created_at = self.created_at();
+impl From<ComixChapter> for Chapter {
+	fn from(value: ComixChapter) -> Self {
+		let created_at = value.created_at();
 		Chapter {
-			key: self.id.to_string(),
-			title: (!self.name.is_empty()).then_some(self.name),
-			chapter_number: Some(self.number),
+			key: value.id.to_string(),
+			title: (!value.name.is_empty()).then_some(value.name),
+			chapter_number: Some(value.number),
 			date_uploaded: Some(created_at),
-			scanlators: if let Some(group) = self.group {
+			scanlators: if let Some(group) = value.group {
 				Some(vec![group.name])
-			} else if self.is_official {
+			} else if value.is_official {
 				Some(vec!["Official".into()])
 			} else {
 				None
 			},
-			url: Some(format!("{BASE_URL}/{}", self.url.trim_start_matches('/'))),
+			url: Some(format!("{BASE_URL}/{}", value.url.trim_start_matches('/'))),
 			..Default::default()
 		}
 	}

--- a/sources/en.comix/src/models.rs
+++ b/sources/en.comix/src/models.rs
@@ -303,6 +303,8 @@ pub struct ComixPages {
 #[derive(Deserialize)]
 pub struct ComixPage {
 	pub url: String,
+	pub width: f32,
+	pub height: f32,
 	pub s: Option<i32>,
 }
 

--- a/sources/en.comix/src/models.rs
+++ b/sources/en.comix/src/models.rs
@@ -126,6 +126,7 @@ pub struct ComixManga {
 	pub genres: Option<Vec<Term>>,
 	pub tags: Option<Vec<Term>>,
 	pub latest_chapter: Option<f32>,
+	pub url: String,
 	// pub has_chapters: bool,
 	// pub chapter_updated_at_formatted: Option<String>,
 }
@@ -182,7 +183,7 @@ impl ComixManga {
 
 impl From<ComixManga> for Manga {
 	fn from(value: ComixManga) -> Self {
-		let url = format!("{BASE_URL}/title/{}", value.hid);
+		let url = format!("{BASE_URL}/{}", value.url.trim_start_matches('/'));
 		Self {
 			key: value.hid,
 			title: value.title,
@@ -239,6 +240,7 @@ pub struct ComixChapter {
 	pub group: Option<ScanlationGroup>,
 	#[serde(deserialize_with = "bool_from_any")]
 	pub is_official: bool,
+	pub url: String,
 }
 
 impl ComixChapter {
@@ -246,7 +248,7 @@ impl ComixChapter {
 		helpers::parse_relative_date_string(&self.created_at_formatted)
 	}
 
-	pub fn into_chapter(self, manga_id: &str) -> Chapter {
+	pub fn into_chapter(self) -> Chapter {
 		let created_at = self.created_at();
 		Chapter {
 			key: self.id.to_string(),
@@ -260,7 +262,7 @@ impl ComixChapter {
 			} else {
 				None
 			},
-			url: Some(format!("{BASE_URL}/title/{manga_id}/{}", self.id)),
+			url: Some(format!("{BASE_URL}/{}", self.url.trim_start_matches('/'))),
 			..Default::default()
 		}
 	}

--- a/sources/en.comix/src/models.rs
+++ b/sources/en.comix/src/models.rs
@@ -303,6 +303,7 @@ pub struct ComixPages {
 #[derive(Deserialize)]
 pub struct ComixPage {
 	pub url: String,
+	pub s: Option<i32>,
 }
 
 // deserialize a bool from a json bool, number, or string

--- a/sources/en.comix/src/web.rs
+++ b/sources/en.comix/src/web.rs
@@ -15,17 +15,27 @@ if (!vmObj || typeof vmObj !== 'object' || vmObj === window) {\
 	return '';\
 }";
 
+const JS_PATCHER: &str = "<head><script>window['originalGetImageData'] = HTMLCanvasElement.prototype.toDataURL;</script>";
+
 pub struct ComixWebView {
 	web_view: WebView,
 	installer_fn: Option<String>,
+	descrambler_fn: Option<String>,
 }
 
 pub fn create_web_view() -> Result<ComixWebView> {
 	let web_view = WebView::new();
-	web_view.load_blocking(Request::get(BASE_URL)?)?;
+	web_view.load_html_blocking(
+		Request::get(BASE_URL)?
+			.string()?
+			.replace("<head>", JS_PATCHER)
+			.as_str(),
+		Some(BASE_URL),
+	)?;
 	let mut comix_web_view = ComixWebView {
 		web_view,
 		installer_fn: None,
+		descrambler_fn: None,
 	};
 	if find_functions(&mut comix_web_view).is_err() {
 		find_secure_module_src(&mut comix_web_view)?;
@@ -76,33 +86,50 @@ fn find_functions(web_view: &mut ComixWebView) -> Result<()> {
 			try {{
 				{GET_VMOBJ_JS}
 				let fnames = Object.keys(vmObj);
+				let inst = '', desc = '';
 				for (let j = 0; j < fnames.length; j++) {{
 					let fn = vmObj[fnames[j]];
 					if (typeof fn !== 'function') continue;
-					try {{
-						let got = false;
-						fn({{
-							interceptors: {{
-								request: {{ use: function() {{}} }},
-								response: {{ use: function() {{ got = true; }} }}
-							}},
-							defaults: {{
-								headers: {{ common: {{}} }},
-								transformRequest: [],
-								transformResponse: []
-							}}
-						}});
-						if (got) return 'window[' + JSON.stringify(vmKey) + '].' + fnames[j];
-					}} catch (e) {{}}
+					let ref = 'window[' + JSON.stringify(vmKey) + '].' + fnames[j];
+					if (!inst) {{
+						try {{
+							let got = false;
+							fn({{
+								interceptors: {{
+									request: {{ use: function() {{}} }},
+									response: {{ use: function() {{ got = true; }} }}
+								}},
+								defaults: {{
+									headers: {{ common: {{}} }},
+									transformRequest: [],
+									transformResponse: []
+								}}
+							}});
+							if (got) inst = ref;
+						}} catch (e) {{}}
+					}}
+					if (!desc) {{
+						if (fn.constructor.name === 'AsyncFunction') {{
+							desc = ref;
+						}}
+					}}
 				}}
+				return inst + '||' + desc
 			}} catch(e) {{}}
 			return '';
 		}})()",
 	))?;
-	if result.is_empty() {
+	let Some((installer_expr, descrambler_expr)) = result.split_once("||") else {
+		bail!("Failed to find installer and descrambler functions")
+	};
+	if installer_expr.is_empty() {
 		bail!("Failed to find installer function");
 	};
-	web_view.installer_fn = Some(result);
+	if descrambler_expr.is_empty() {
+		bail!("Failed to find descrambler function");
+	};
+	web_view.installer_fn = Some(installer_expr.into());
+	web_view.descrambler_fn = Some(descrambler_expr.into());
 	Ok(())
 }
 
@@ -207,4 +234,52 @@ pub fn decode_response(web_view: &ComixWebView, url: &str, encoded_res: &str) ->
 		bail!("Failed to fetch token")
 	}
 	Ok(result)
+}
+
+pub fn descramble_image(
+	web_view: &ComixWebView,
+	width: f32,
+	height: f32,
+	url: &str,
+) -> Result<String> {
+	let Some(descrambler_fn) = web_view.descrambler_fn.as_ref() else {
+		bail!("Missing descramble function")
+	};
+
+	web_view.web_view.eval(&format!(
+		"(() => {{
+		const canvas = document.createElement('canvas');
+		canvas.width = {width};
+		canvas.height = {height};
+
+		window['TEMP_CANVAS'] = canvas;
+		window['TEMP_STATE'] = {{ isDone: false, error: null }}
+
+		{GET_VMOBJ_JS}
+		{descrambler_fn}('{url}', canvas)
+			.then(() => window['TEMP_STATE'].isDone = true)
+			.catch((e) => {{ window['TEMP_STATE'].isDone = true; window['TEMP_STATE'].error = e }});
+
+		return '';
+	}})()"
+	))?;
+
+	while web_view
+		.web_view
+		.eval("(() => { return window['TEMP_STATE'].isDone ? 'true' : 'false'; })()")?
+		== "false"
+	{}
+
+	let result = web_view.web_view.eval(
+		"(() => {{
+		const data = window['originalGetImageData'].call(window['TEMP_CANVAS']);
+		return data;
+	}})()",
+	)?;
+
+	if result.is_empty() {
+		bail!("Failed to descramble image")
+	} else {
+		Ok(result)
+	}
 }

--- a/sources/en.comix/src/web.rs
+++ b/sources/en.comix/src/web.rs
@@ -1,7 +1,7 @@
 // reference: https://github.com/nobottomline/extensions-source/blob/c8fe930f315f3baee23587559edfceab5e969202/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Signer.kt
 use crate::BASE_URL;
 use aidoku::{
-	AidokuError, Result,
+	Result,
 	alloc::string::String,
 	imports::{js::WebView, net::Request},
 	prelude::*,
@@ -50,14 +50,16 @@ fn find_secure_module_src(web_view: &mut ComixWebView) -> Result<()> {
 		.select("head > script[type=\"module\"][src*=\"main\"]")
 		.and_then(|e| e.first())
 		.and_then(|e| e.attr("src"))
-		.ok_or(AidokuError::message("Main module not found"))?;
+		.ok_or(error!("Main module not found"))?;
 	if let Some(js_asset_path_index) = main_module_src.rfind("/") {
 		let js_asset_path = &main_module_src[0..js_asset_path_index + 1];
 		let secure_script_regex = Regex::new("(secure-[A-Za-z0-9-_]+?\\.js)").unwrap();
 		let main_module_contents =
 			Request::get(format!("{BASE_URL}{main_module_src}"))?.string()?;
-		if let Some(captures) = secure_script_regex.captures(main_module_contents.as_str()) {
-			let secure_script_path = captures.get(1).unwrap().as_str();
+		if let Some(secure_script_path) = secure_script_regex
+			.captures(main_module_contents.as_str())
+			.and_then(|captures| captures.get(1).map(|m| m.as_str()))
+		{
 			web_view.web_view.eval(&format!(
 				"(() => {{
 				import('{BASE_URL}{js_asset_path}{secure_script_path}')

--- a/sources/en.comix/src/web.rs
+++ b/sources/en.comix/src/web.rs
@@ -1,11 +1,12 @@
 // reference: https://github.com/nobottomline/extensions-source/blob/c8fe930f315f3baee23587559edfceab5e969202/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Signer.kt
 use crate::BASE_URL;
 use aidoku::{
-	Result,
+	AidokuError, Result,
 	alloc::string::String,
 	imports::{js::WebView, net::Request},
 	prelude::*,
 };
+use regex::Regex;
 
 const GET_VMOBJ_JS: &str = "\
 const vmKey = Object.keys(window).find(key => key.startsWith('vm'));\
@@ -26,8 +27,49 @@ pub fn create_web_view() -> Result<ComixWebView> {
 		web_view,
 		installer_fn: None,
 	};
-	find_functions(&mut comix_web_view)?;
+	if find_functions(&mut comix_web_view).is_err() {
+		find_secure_module_src(&mut comix_web_view)?;
+		find_functions(&mut comix_web_view)?;
+	}
 	Ok(comix_web_view)
+}
+
+fn find_secure_module_src(web_view: &mut ComixWebView) -> Result<()> {
+	let main_module_src = Request::get(BASE_URL)?
+		.html()?
+		.select("head > script[type=\"module\"][src*=\"main\"]")
+		.and_then(|e| e.first())
+		.and_then(|e| e.attr("src"))
+		.ok_or(AidokuError::message("Main module not found"))?;
+	if let Some(js_asset_path_index) = main_module_src.rfind("/") {
+		let js_asset_path = &main_module_src[0..js_asset_path_index + 1];
+		let secure_script_regex = Regex::new("(secure-[A-Za-z0-9-_]+?\\.js)").unwrap();
+		let main_module_contents =
+			Request::get(format!("{BASE_URL}{main_module_src}"))?.string()?;
+		if let Some(captures) = secure_script_regex.captures(main_module_contents.as_str()) {
+			let secure_script_path = captures.get(1).unwrap().as_str();
+			web_view.web_view.eval(&format!(
+				"(() => {{
+				try {{
+					import('{BASE_URL}{js_asset_path}{secure_script_path}')
+						.then((m) => window['vm'] = m)
+						.catch((e) => window['vm'] = {{}});
+				}} catch (e) => {{ window['vm'] = {{}}; }}
+				return '';
+			}})()"
+			))?;
+			while web_view
+				.web_view
+				.eval("(() => { return window['vm'] != null ? 'true' : 'false'; })()")?
+				.starts_with("false")
+			{}
+			Ok(())
+		} else {
+			bail!("Secure module not found");
+		}
+	} else {
+		bail!("Invalid path")
+	}
 }
 
 fn find_functions(web_view: &mut ComixWebView) -> Result<()> {
@@ -43,7 +85,7 @@ fn find_functions(web_view: &mut ComixWebView) -> Result<()> {
 						let got = false;
 						fn({{
 							interceptors: {{
-								request:{{ use: function() {{}} }},
+								request: {{ use: function() {{}} }},
 								response: {{ use: function() {{ got = true; }} }}
 							}},
 							defaults: {{

--- a/sources/en.comix/src/web.rs
+++ b/sources/en.comix/src/web.rs
@@ -274,6 +274,7 @@ pub fn descramble_image(
 
 	let result = web_view.web_view.eval(
 		"(() => {{
+		if (window['TEMP_STATE'].error) return '';
 		const data = window['originalGetImageData'].call(window['TEMP_CANVAS']);
 		return data;
 	}})()",

--- a/sources/en.comix/src/web.rs
+++ b/sources/en.comix/src/web.rs
@@ -50,18 +50,16 @@ fn find_secure_module_src(web_view: &mut ComixWebView) -> Result<()> {
 			let secure_script_path = captures.get(1).unwrap().as_str();
 			web_view.web_view.eval(&format!(
 				"(() => {{
-				try {{
-					import('{BASE_URL}{js_asset_path}{secure_script_path}')
-						.then((m) => window['vm'] = m)
-						.catch((e) => window['vm'] = {{}});
-				}} catch (e) => {{ window['vm'] = {{}}; }}
+				import('{BASE_URL}{js_asset_path}{secure_script_path}')
+					.then((m) => window['vm'] = m)
+					.catch((e) => window['vm'] = {{}});
 				return '';
 			}})()"
 			))?;
 			while web_view
 				.web_view
-				.eval("(() => { return window['vm'] != null ? 'true' : 'false'; })()")?
-				.starts_with("false")
+				.eval("(() => { return window['vm'] == null ? 'true' : 'false'; })()")?
+				== "true"
 			{}
 			Ok(())
 		} else {


### PR DESCRIPTION
# Summary
This PR attempt to solve existing comix issues by adding fallback path if installer fails.

Installer will now do the following:
- Check for `vm` objects and probe each key for existing functions
- If fails, load the ES module into `vm` object and try searching again
- If all else fails, it should return an error on the user end

This new installer ensures that it will survive the current changes as they keep rotating between them every day.

After a few changes, comix now decided to scramble images. This PR will also handle scrambled images via web_view by loading a custom canvas and dump the image data out. The raw image is PNG in base64 format.

# Scrambled Images
Some Comix pages are marked with `s: 1` and use scrambled `/si/` or `/sii/` image routes.

- Normal page remain unchanged.
- If they are marked as scrambled, it would use the descrambler to get the original image.

The reason why this PR isn't changing the URL is because of the potential breaking image routes. As we figure out, pages marked with `s: 1` will return 404 errors if you do not have the required request header. This is enforced properly if you use the descrambler function. Conversely, if you were to add custom request header into non scrambled routes, you will get 404 as well. This is really annoying, and you might end up getting no image at all if you try changing URL and testing them.

So the best solution is, keep the image route as is, let the descrambler handle them. They can't break this unless they change the requirement.

For every scrambled image, the output result would convert the image into PNG file in base64 format. This is a limitation set by IOS devices since web_view internally uses the device browser and all browser uses the same web kit engine anyway.

Then again PNG is a lossless format so it will not make the image any less blurry than before. Since it is just a slightly bigger size image, that shouldn't be much issue.

# PR Checklist
- [x] The source can be compiled without any warnings or errors.
- [x] cargo fmt has been run before submission.
- [x] cargo clippy outputs no lint warnings.
- [x] All files have an additional newline at the end.
- [x] JSON files use tabs for indentation.

### Notes
This is just a proof of concept that I made that I am testing which may help if they ever decided to move the code to ES module making it impossible to find via window object. It happens once and who knows if they ever rotate back to that again.

Making this as a draft as the code is probably not the cleanest thing and need testing. (Sorry, my rust knowledge is not that great)
There is no way for me to handle async function properly without ugly hacks like the while loop.

comix had yet to change anything with the axios interceptors for a while now. They are always exposed in the module. We are now using the interceptors to handle both signing the request and decoding the response.

Feel free to comment if you have any other better idea while we wait and see what comix would do.
(Maybe we won't even need this as comix loves changing stuff that it make this obsolete)