### PR TITLE
fix(en.comix): update reader flow and scrambled image handling

### DIFF
--- a/sources/en.comix/Cargo.lock
+++ b/sources/en.comix/Cargo.lock
@@ -62,12 +62,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,8 +88,6 @@ version = "0.1.0"
 dependencies = [
  "aidoku",
  "aidoku-test",
- "base64",
- "regex",
  "serde",
  "serde_json",
 ]
@@ -240,31 +232,6 @@ checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
-dependencies = [
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustc_version"

--- a/sources/en.comix/Cargo.toml
+++ b/sources/en.comix/Cargo.toml
@@ -10,8 +10,6 @@ crate-type = ["cdylib"]
 aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", features = ["json"] }
 serde = { version = "1.0", features = ["derive", "alloc"], default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
-regex = { version = "1.12", default-features = false }
-base64 = { version = "0.22", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", features = ["test"] }

--- a/sources/en.comix/res/source.json
+++ b/sources/en.comix/res/source.json
@@ -2,7 +2,7 @@
 	"info": {
 		"id": "en.comix",
 		"name": "Comix",
-		"version": 16,
+		"version": 18,
 		"url": "https://comix.to",
 		"contentRating": 1,
 		"languages": ["en"]

--- a/sources/en.comix/src/images.rs
+++ b/sources/en.comix/src/images.rs
@@ -1,0 +1,535 @@
+use crate::{BASE_URL, Comix, models::ComixPage, web};
+use aidoku::{
+	ImageResponse, Page, PageContent, PageContext, PageImageProcessor, Result,
+	alloc::{String, Vec, string::ToString, vec},
+	imports::{
+		canvas::{Canvas, ImageRef, Rect},
+		net::{Request, Response},
+	},
+	prelude::*,
+};
+
+const SCRAMBLED_PAGE_GRID_CONTEXT_KEY: &str = "comixScrambleGrid";
+const SCRAMBLED_PAGE_MAP_CONTEXT_KEY: &str = "comixScrambleMap";
+pub const PAGE_S_FLAG_CONTEXT_KEY: &str = "comixPageS";
+const PAGE_WIDTH_CONTEXT_KEY: &str = "comixPageWidth";
+const PAGE_HEIGHT_CONTEXT_KEY: &str = "comixPageHeight";
+
+/// Builds the page list, batching the s:1 clean-route and scramble-metadata
+/// probes through `send_all` so latency scales with round-trips, not page count.
+pub fn build_page_list(source: &Comix, base_url: &str, items: Vec<ComixPage>) -> Result<Vec<Page>> {
+	let resolved: Vec<ResolvedPage> = items
+		.into_iter()
+		.enumerate()
+		.map(|(index, page)| ResolvedPage::new(base_url, page, index))
+		.collect::<Result<Vec<_>>>()?;
+
+	let clean_available = probe_clean_routes(&resolved);
+	let scramble_headers = probe_scramble_headers(&resolved, &clean_available);
+
+	let pages = resolved
+		.into_iter()
+		.enumerate()
+		.map(|(i, page)| Page {
+			content: page.into_content(
+				source,
+				clean_available.get(&i).copied().unwrap_or(false),
+				scramble_headers.get(&i),
+			),
+			..Default::default()
+		})
+		.collect();
+	Ok(pages)
+}
+
+struct ResolvedPage {
+	url: String,
+	index: usize,
+	s_flag: bool,
+	scrambled_bounds: Option<(usize, usize)>,
+	width: f32,
+	height: f32,
+}
+
+impl ResolvedPage {
+	fn new(base_url: &str, page: ComixPage, index: usize) -> Result<Self> {
+		let (width, height) = (page.width, page.height);
+		let url = absolute_page_url(base_url, page.url)?;
+		let s_flag = page.s == Some(1);
+		let scrambled_bounds = s_flag.then(|| scrambled_route_bounds(&url)).flatten();
+		Ok(Self {
+			url,
+			index,
+			s_flag,
+			scrambled_bounds,
+			width,
+			height,
+		})
+	}
+
+	fn clean_probe(&self) -> Option<(usize, String)> {
+		self.scrambled_bounds
+			.map(|(start, end)| (self.index, clean_image_url(&self.url, start, end)))
+	}
+
+	fn into_content(
+		self,
+		source: &Comix,
+		clean_available: bool,
+		scramble: Option<&PageScramble>,
+	) -> PageContent {
+		if !self.s_flag {
+			return PageContent::url(self.url);
+		}
+		let (width, height) = (self.width, self.height);
+		let Some((start, end)) = self.scrambled_bounds else {
+			// s:1 but the URL doesn't match a known scrambled route — still
+			// carry the s:1 context so get_image_request adds Origin.
+			return PageContent::url_context(self.url, with_dims(s_flag_context(), width, height));
+		};
+		if clean_available {
+			return PageContent::url_context(
+				clean_image_url(&self.url, start, end),
+				with_dims(s_flag_context(), width, height),
+			);
+		}
+		// Build the descramble context locally so image processing at render
+		// time doesn't need to touch the WebView.
+		let context = scramble
+			.and_then(|s| source.prepare_scrambled_page_context(&s.seed, &s.grid))
+			.unwrap_or_else(s_flag_context);
+		// When the seed/grid came from a cache-busted probe, fetch the image from
+		// the same busted URL so its bytes match the seed the map was built from.
+		let url = if scramble.is_some_and(|s| s.cache_bust) {
+			let separator = if self.url.contains('?') { '&' } else { '?' };
+			format!("{}{separator}r=1", self.url)
+		} else {
+			self.url
+		};
+		PageContent::url_context(url, with_dims(context, width, height))
+	}
+}
+
+fn probe_clean_routes(resolved: &[ResolvedPage]) -> aidoku::HashMap<usize, bool> {
+	let requests: Vec<(usize, Request)> = resolved
+		.iter()
+		.filter_map(|p| {
+			let (index, clean_url) = p.clean_probe()?;
+			Some((index, apply_s1_headers(Request::head(&clean_url).ok()?)))
+		})
+		.collect();
+	batch_responses(requests)
+		.into_iter()
+		.map(|(index, response)| (index, is_image_response(response.as_ref())))
+		.collect()
+}
+
+enum ScrambleProbe {
+	Valid(String, String),
+	/// No usable seed/grid (e.g. the CDN's `X-Scramble-Seed: 0` response); the
+	/// caller retries with a cache-bust, then falls through to the raw image.
+	Unknown,
+}
+
+struct PageScramble {
+	seed: String,
+	grid: String,
+	/// The plain URL returned a degraded `seed:0` response and the real seed/grid
+	/// only came back from a cache-busted request, so the image must be fetched
+	/// from the busted URL too.
+	cache_bust: bool,
+}
+
+/// Fetches X-Scramble-Seed/Grid for s:1 pages without a clean `/i/` route via a
+/// HEAD batch. The CDN sometimes caches a degraded response (`seed:0`/no grid)
+/// for a page that is actually scrambled; a second HEAD with a cache-busting
+/// param forces a fresh response with the real seed/grid (the website recovers
+/// the same way). Pages still without seed/grid aren't scrambled and fall
+/// through to the raw image.
+fn probe_scramble_headers(
+	resolved: &[ResolvedPage],
+	clean_available: &aidoku::HashMap<usize, bool>,
+) -> aidoku::HashMap<usize, PageScramble> {
+	let targets: aidoku::HashMap<usize, &str> = resolved
+		.iter()
+		.filter(|p| {
+			p.s_flag
+				&& p.scrambled_bounds.is_some()
+				&& !clean_available.get(&p.index).copied().unwrap_or(false)
+		})
+		.map(|p| (p.index, p.url.as_str()))
+		.collect();
+	if targets.is_empty() {
+		return aidoku::HashMap::new();
+	}
+
+	let mut results = aidoku::HashMap::new();
+	let head_requests: Vec<(usize, Request)> = targets
+		.iter()
+		.filter_map(|(&i, &url)| Some((i, apply_s1_headers(Request::head(url).ok()?))))
+		.collect();
+	let mut unresolved = Vec::new();
+	for (index, response) in batch_responses(head_requests) {
+		match extract_scramble_probe(response) {
+			ScrambleProbe::Valid(seed, grid) => {
+				results.insert(
+					index,
+					PageScramble {
+						seed,
+						grid,
+						cache_bust: false,
+					},
+				);
+			}
+			ScrambleProbe::Unknown => unresolved.push(index),
+		}
+	}
+
+	let bust_requests: Vec<(usize, Request)> = unresolved
+		.into_iter()
+		.filter_map(|index| {
+			let url = *targets.get(&index)?;
+			let separator = if url.contains('?') { '&' } else { '?' };
+			let busted = format!("{url}{separator}r=1");
+			Some((index, apply_s1_headers(Request::head(&busted).ok()?)))
+		})
+		.collect();
+	for (index, response) in batch_responses(bust_requests) {
+		if let ScrambleProbe::Valid(seed, grid) = extract_scramble_probe(response) {
+			results.insert(
+				index,
+				PageScramble {
+					seed,
+					grid,
+					cache_bust: true,
+				},
+			);
+		}
+	}
+	results
+}
+
+/// Sends every `(index, request)` in parallel, flattening transport errors to `None`.
+fn batch_responses(requests: Vec<(usize, Request)>) -> Vec<(usize, Option<Response>)> {
+	if requests.is_empty() {
+		return Vec::new();
+	}
+	let (indices, reqs): (Vec<usize>, Vec<Request>) = requests.into_iter().unzip();
+	Request::send_all(reqs)
+		.into_iter()
+		.zip(indices)
+		.map(|(result, index)| (index, result.ok()))
+		.collect()
+}
+
+fn is_image_response(response: Option<&Response>) -> bool {
+	let Some(response) = response else {
+		return false;
+	};
+	let content_type = response
+		.get_header("Content-Type")
+		.unwrap_or_default()
+		.to_lowercase();
+	(200..400).contains(&response.status_code()) && content_type.starts_with("image/")
+}
+
+fn extract_scramble_probe(response: Option<Response>) -> ScrambleProbe {
+	let Some(response) = response.filter(|r| (200..400).contains(&r.status_code())) else {
+		return ScrambleProbe::Unknown;
+	};
+	let seed = response.get_header("X-Scramble-Seed");
+	let grid = response.get_header("X-Scramble-Grid");
+	match (seed, grid) {
+		(Some(seed), Some(grid)) => ScrambleProbe::Valid(seed, grid),
+		// `seed:0`/missing grid means the page isn't scrambled — use the raw image.
+		_ => ScrambleProbe::Unknown,
+	}
+}
+
+fn absolute_page_url(base_url: &str, page_url: String) -> Result<String> {
+	if page_url.starts_with("http://") || page_url.starts_with("https://") {
+		Ok(page_url)
+	} else {
+		let base_url = base_url.trim_end_matches('/');
+		if base_url.is_empty() {
+			bail!("Comix page list is missing an image base URL")
+		}
+		Ok(format!("{base_url}/{}", page_url.trim_start_matches('/')))
+	}
+}
+
+// Comix s:1 images need Origin alongside Referer; missing Origin returns 404
+// from the CDN. Non-s:1 images must not use these headers.
+fn apply_s1_headers(request: Request) -> Request {
+	request
+		.header("Referer", &format!("{BASE_URL}/"))
+		.header("Origin", BASE_URL)
+}
+
+fn s_flag_context() -> PageContext {
+	let mut context = PageContext::new();
+	context.insert(PAGE_S_FLAG_CONTEXT_KEY.into(), "1".into());
+	context
+}
+
+fn scrambled_page_context(grid: &str, map: &[usize]) -> PageContext {
+	let mut context = s_flag_context();
+	context.insert(SCRAMBLED_PAGE_GRID_CONTEXT_KEY.into(), grid.into());
+	context.insert(SCRAMBLED_PAGE_MAP_CONTEXT_KEY.into(), encode_tile_map(map));
+	context
+}
+
+fn encode_tile_map(map: &[usize]) -> String {
+	map.iter()
+		.map(usize::to_string)
+		.collect::<Vec<_>>()
+		.join(",")
+}
+
+fn parse_tile_map(value: &str) -> Result<Vec<usize>> {
+	value
+		.split(',')
+		.map(|item| {
+			item.parse::<usize>()
+				.map_err(|_| error!("Comix image descrambler tile map is invalid"))
+		})
+		.collect()
+}
+
+fn parse_scramble_grid(grid: &str) -> Result<(usize, usize)> {
+	grid.split_once('x')
+		.and_then(|(c, r)| Some((c.parse::<usize>().ok()?, r.parse::<usize>().ok()?)))
+		.filter(|(c, r)| (1..=20).contains(c) && (1..=20).contains(r))
+		.ok_or_else(|| error!("Comix image scramble grid is invalid: {grid}"))
+}
+
+fn descramble_image(image: &ImageRef, map: &[usize], cols: usize, rows: usize) -> Result<ImageRef> {
+	let total = cols * rows;
+	if map.len() != total {
+		bail!("Comix image descrambler returned an invalid tile count")
+	}
+
+	let mut seen = vec![false; total];
+	for &dest in map {
+		if dest >= total || seen[dest] {
+			bail!("Comix image descrambler returned an invalid tile map")
+		}
+		seen[dest] = true;
+	}
+
+	let image_width = image.width();
+	let image_height = image.height();
+	let tile_width = (image_width as usize / cols) as f32;
+	let tile_height = (image_height as usize / rows) as f32;
+	if tile_width <= 0.0 || tile_height <= 0.0 {
+		bail!("Comix image is too small for its scramble grid")
+	}
+
+	let mut canvas = Canvas::new(image_width, image_height);
+	// Base layer: integer tile division can leave a few-pixel remainder strip on
+	// the right/bottom edges that the per-tile copies below never overwrite.
+	canvas.draw_image(image, Rect::new(0.0, 0.0, image_width, image_height));
+
+	for (source, &dest) in map.iter().enumerate() {
+		let source_x = (source % cols) as f32 * tile_width;
+		let source_y = (source / cols) as f32 * tile_height;
+		let dest_x = (dest % cols) as f32 * tile_width;
+		let dest_y = (dest / cols) as f32 * tile_height;
+		canvas.copy_image(
+			image,
+			Rect::new(source_x, source_y, tile_width, tile_height),
+			Rect::new(dest_x, dest_y, tile_width, tile_height),
+		);
+	}
+
+	Ok(canvas.get_image())
+}
+
+fn clean_image_url(url: &str, start: usize, end: usize) -> String {
+	let mut clean_url = url.to_string();
+	clean_url.replace_range(start..end, "i");
+	clean_url
+}
+
+/// Returns the byte offsets of the `si`/`sii` segment within `url` so the caller
+/// can rewrite it to `i` in-place; `None` for any URL that doesn't match the
+/// `<host>/(si|sii)/<token>/<filename>` shape Comix uses for scrambled images.
+fn scrambled_route_bounds(url: &str) -> Option<(usize, usize)> {
+	let path_end = url.find(['?', '#']).unwrap_or(url.len());
+	let path_start = if let Some(i) = url.find("://") {
+		i + 3 + url.get(i + 3..path_end)?.find('/')?
+	} else if url.starts_with('/') {
+		0
+	} else {
+		return None;
+	};
+
+	let mut segments = url[path_start + 1..path_end].split('/');
+	let route = segments.next()?;
+	let token = segments.next()?;
+	let filename = segments.next()?;
+	if segments.next().is_some()
+		|| !matches!(route, "si" | "sii")
+		|| !is_comix_image_token(token)
+		|| !filename.contains('.')
+	{
+		return None;
+	}
+	let start = path_start + 1;
+	Some((start, start + route.len()))
+}
+
+fn is_comix_image_token(token: &str) -> bool {
+	token.len() >= 16
+		&& token
+			.chars()
+			.all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '~' | '='))
+}
+
+impl Comix {
+	fn prepare_scrambled_page_context(&self, seed: &str, grid: &str) -> Option<PageContext> {
+		let map_key = format!("{seed}:{grid}");
+		if let Some(map) = self.scramble_maps.borrow().get(&map_key) {
+			return Some(scrambled_page_context(grid, map));
+		}
+		let map = web::get_scramble_map(&mut self.web_view.borrow_mut(), seed, grid).ok()?;
+		self.scramble_maps.borrow_mut().insert(map_key, map.clone());
+		Some(scrambled_page_context(grid, &map))
+	}
+}
+
+impl PageImageProcessor for Comix {
+	fn process_page_image(
+		&self,
+		response: ImageResponse,
+		context: Option<PageContext>,
+	) -> Result<ImageRef> {
+		let context = context.as_ref();
+		let source_url = response.request.url.clone();
+
+		// Descramble when we have a tile map, otherwise use the raw image.
+		let image = finish_image(response.image, context);
+		if is_valid_image(&image) {
+			return Ok(image);
+		}
+
+		// The CDN intermittently serves a truncated, undecodable image; the
+		// website recovers by re-requesting with a cache-busting param, so mirror
+		// that to keep the page rather than losing it.
+		if let Some(retried) = source_url
+			.and_then(|url| refetch_page_image(&url, context))
+			.filter(is_valid_image)
+		{
+			return Ok(retried);
+		}
+
+		// A genuinely broken page (truncated even after retry) would decode to a
+		// zero-sized image; the reader divides by the page height for layout and a
+		// NaN frame crashes the app (Aidoku#991). Fall back to a blank page at the
+		// real dimensions so it lays out like the site's errored-page placeholder.
+		Ok(placeholder_image(context))
+	}
+}
+
+/// Descrambles `image` when the context carries a tile map, otherwise returns it
+/// unchanged.
+fn finish_image(image: ImageRef, context: Option<&PageContext>) -> ImageRef {
+	try_descramble(&image, context).unwrap_or(image)
+}
+
+/// Re-requests a page image with a cache-busting param (mirroring the website's
+/// own retry) and processes it, to recover the occasional truncated image.
+fn refetch_page_image(url: &str, context: Option<&PageContext>) -> Option<ImageRef> {
+	let separator = if url.contains('?') { '&' } else { '?' };
+	let mut request = Request::get(format!("{url}{separator}r=1"))
+		.ok()?
+		.header("Referer", &format!("{BASE_URL}/"));
+	if context.is_some_and(|c| c.get(PAGE_S_FLAG_CONTEXT_KEY).is_some()) {
+		request = request.header("Origin", BASE_URL);
+	}
+	Some(finish_image(request.image().ok()?, context))
+}
+
+fn is_valid_image(image: &ImageRef) -> bool {
+	let (width, height) = (image.width(), image.height());
+	width.is_finite() && height.is_finite() && width >= 1.0 && height >= 1.0
+}
+
+/// A blank image sized to the page's real dimensions when known, so a broken
+/// page lays out at the correct size instead of collapsing the reader layout.
+fn placeholder_image(context: Option<&PageContext>) -> ImageRef {
+	let (width, height) = context.and_then(page_dimensions).unwrap_or((1.0, 1.0));
+	Canvas::new(width, height).get_image()
+}
+
+/// Stores the page's pixel dimensions in `context` so a failed page can be laid
+/// out at its real size (the API provides these per page).
+fn with_dims(mut context: PageContext, width: f32, height: f32) -> PageContext {
+	if width >= 1.0 && height >= 1.0 {
+		context.insert(PAGE_WIDTH_CONTEXT_KEY.into(), width.to_string());
+		context.insert(PAGE_HEIGHT_CONTEXT_KEY.into(), height.to_string());
+	}
+	context
+}
+
+fn page_dimensions(context: &PageContext) -> Option<(f32, f32)> {
+	let width = context.get(PAGE_WIDTH_CONTEXT_KEY)?.parse::<f32>().ok()?;
+	let height = context.get(PAGE_HEIGHT_CONTEXT_KEY)?.parse::<f32>().ok()?;
+	(width >= 1.0 && height >= 1.0).then_some((width, height))
+}
+
+fn try_descramble(image: &ImageRef, context: Option<&PageContext>) -> Option<ImageRef> {
+	let context = context?;
+	let grid = context.get(SCRAMBLED_PAGE_GRID_CONTEXT_KEY)?;
+	let map = parse_tile_map(context.get(SCRAMBLED_PAGE_MAP_CONTEXT_KEY)?).ok()?;
+	let (cols, rows) = parse_scramble_grid(grid).ok()?;
+	descramble_image(image, &map, cols, rows).ok()
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use aidoku_test::aidoku_test;
+
+	const TOKEN: &str = "testImageRouteToken0123456789";
+
+	fn clean(path: &str) -> Option<String> {
+		let url = format!("https://cdn.example.com{path}");
+		scrambled_route_bounds(&url).map(|(start, end)| clean_image_url(&url, start, end))
+	}
+
+	#[aidoku_test]
+	fn normalizes_known_scrambled_routes() {
+		assert_eq!(
+			clean(&format!("/si/{TOKEN}/03.webp")),
+			Some(format!("https://cdn.example.com/i/{TOKEN}/03.webp"))
+		);
+		assert_eq!(
+			clean(&format!("/sii/{TOKEN}/03.webp")),
+			Some(format!("https://cdn.example.com/i/{TOKEN}/03.webp"))
+		);
+	}
+
+	#[aidoku_test]
+	fn does_not_guess_unknown_scrambled_routes() {
+		assert_eq!(clean(&format!("/future/{TOKEN}/03.webp")), None);
+	}
+
+	#[aidoku_test]
+	fn keeps_normal_pages_and_preserves_suffixes() {
+		assert_eq!(clean(&format!("/i/{TOKEN}/03.webp")), None);
+		assert_eq!(
+			clean(&format!("/sii/{TOKEN}/03.webp?size=large#page")),
+			Some(format!(
+				"https://cdn.example.com/i/{TOKEN}/03.webp?size=large#page"
+			))
+		);
+	}
+
+	#[aidoku_test]
+	fn avoids_substring_and_unknown_shape_rewrites() {
+		assert_eq!(clean(&format!("/sii-extra/{TOKEN}/03.webp")), None);
+		assert_eq!(clean(&format!("/path/sii/{TOKEN}/03.webp")), None);
+		assert_eq!(clean("/si/short/03.webp"), None);
+	}
+}

--- a/sources/en.comix/src/lib.rs
+++ b/sources/en.comix/src/lib.rs
@@ -1,11 +1,8 @@
 #![no_std]
-
-use aidoku::imports::canvas::ImageRef;
 use aidoku::{
 	Chapter, DeepLinkHandler, DeepLinkResult, FilterValue, HashMap, Home, HomeComponent,
-	HomeLayout, HomePartialResult, ImageRequestProvider, ImageResponse, Link, LinkValue, Listing,
-	ListingProvider, Manga, MangaPageResult, MangaWithChapter, NotificationHandler, Page,
-	PageContent, PageContext, PageImageProcessor, Result, Source,
+	HomeLayout, HomePartialResult, ImageRequestProvider, Link, LinkValue, Listing, ListingProvider,
+	Manga, MangaPageResult, MangaWithChapter, NotificationHandler, Page, Result, Source,
 	alloc::{String, Vec, string::ToString, vec},
 	helpers::uri::{QueryParameters, encode_uri_component},
 	imports::{
@@ -14,9 +11,10 @@ use aidoku::{
 	},
 	prelude::*,
 };
-use base64::{Engine, engine::general_purpose};
+use core::cell::RefCell;
 
 mod helpers;
+mod images;
 mod models;
 mod settings;
 mod web;
@@ -30,11 +28,17 @@ const CONTENT_TYPES: &[&str] = &["manga", "manhwa", "manhua", "other"];
 // adult, boys love, ecchi, girls love, hentai, smut
 const NSFW_GENRE_IDS: &[&str] = &["87264", "8", "87265", "13", "87266", "87268"];
 
-struct Comix;
+struct Comix {
+	web_view: RefCell<Option<web::ComixWebView>>,
+	scramble_maps: RefCell<HashMap<String, Vec<usize>>>,
+}
 
 impl Source for Comix {
 	fn new() -> Self {
-		Self
+		Self {
+			web_view: RefCell::new(None),
+			scramble_maps: RefCell::new(HashMap::new()),
+		}
 	}
 
 	fn get_search_manga_list(
@@ -45,8 +49,9 @@ impl Source for Comix {
 	) -> Result<MangaPageResult> {
 		let mut qs = QueryParameters::new();
 		qs.push("page", Some(&page.to_string()));
-		if query.is_some() {
-			qs.push("keyword", query.as_deref());
+		let query = query.as_deref().map(str::trim).filter(|q| !q.is_empty());
+		if let Some(query) = query {
+			qs.push("keyword", Some(query));
 		}
 
 		let mut hidden_types = {
@@ -180,6 +185,10 @@ impl Source for Comix {
 		needs_details: bool,
 		needs_chapters: bool,
 	) -> Result<Manga> {
+		if manga.key.is_empty() {
+			bail!("Comix title is unavailable")
+		}
+
 		if needs_details {
 			let url = format!(
 				"{API_URL}/manga/{}/?includes[]=demographic\
@@ -201,49 +210,57 @@ impl Source for Comix {
 
 		if needs_chapters {
 			let limit = 100;
-			let mut page = 1;
 			let deduplicate = settings::dedupchapter();
 			let mut chapter_map: HashMap<String, ComixChapter> = HashMap::new();
 			let mut chapter_list: Vec<ComixChapter> = Vec::new();
-
-			let web_view = web::create_web_view()?;
 			let path = format!("/manga/{}/chapters", manga.key);
-			let token = web::get_token(&web_view, &path)?;
+			let page_url =
+				|page: i32| format!("{API_URL}{path}?limit={limit}&page={page}&order[number]=desc");
 
-			loop {
-				let url = format!(
-					"{API_URL}{path}\
-						?limit={limit}\
-						&page={page}\
-						&order[number]=desc\
-						&_={token}"
-				);
-
-				let encoded_res = Request::get(&url)?.string()?;
-				let result = web::decode_response(&web_view, &url, &encoded_res)?;
-				let res = serde_json::from_str::<ChapterDetailsResponse>(&result)?;
-
-				let items = res.result.items;
-
+			let absorb = |items: Vec<ComixChapter>,
+			              map: &mut HashMap<String, ComixChapter>,
+			              list: &mut Vec<ComixChapter>| {
 				if deduplicate {
 					for item in items {
-						helpers::dedup_insert(&mut chapter_map, item);
+						helpers::dedup_insert(map, item);
 					}
 				} else {
-					chapter_list.extend(items);
+					list.extend(items);
 				}
+			};
 
-				if res.result.meta.page >= res.result.meta.last_page {
-					break;
+			// Page 1 alone so we can read `last_page` before fetching the rest.
+			let first_body = {
+				let mut web_view = self.web_view.borrow_mut();
+				web::get_api_response(&mut web_view, &path, &page_url(1))?
+			};
+			let first: ChapterDetailsResponse = serde_json::from_str(&first_body)?;
+			let last_page = first.result.meta.last_page;
+			absorb(first.result.items, &mut chapter_map, &mut chapter_list);
+
+			if last_page > 1 {
+				let urls: Vec<String> = (2..=last_page).map(page_url).collect();
+				let url_refs: Vec<&str> = urls.iter().map(String::as_str).collect();
+				let bodies = {
+					let mut web_view = self.web_view.borrow_mut();
+					web::get_api_responses(&mut web_view, &path, &url_refs)?
+				};
+				for body in bodies {
+					let res: ChapterDetailsResponse = serde_json::from_str(&body)?;
+					absorb(res.result.items, &mut chapter_map, &mut chapter_list);
 				}
-
-				page += 1;
 			}
 
 			let mut chapters: Vec<Chapter> = if deduplicate {
-				chapter_map.into_values().map(Into::into).collect()
+				chapter_map
+					.into_values()
+					.map(|item| item.into_chapter())
+					.collect()
 			} else {
-				chapter_list.into_iter().map(Into::into).collect()
+				chapter_list
+					.into_iter()
+					.map(|item| item.into_chapter())
+					.collect()
 			};
 
 			if deduplicate {
@@ -261,49 +278,30 @@ impl Source for Comix {
 	}
 
 	fn get_page_list(&self, _manga: Manga, chapter: Chapter) -> Result<Vec<Page>> {
-		let web_view = web::create_web_view()?;
 		let path = format!("/chapters/{}", chapter.key);
-		let token = web::get_token(&web_view, &path)?;
-		let url = format!("{API_URL}{path}?_={token}");
-		let encoded_res = Request::get(&url)?.string()?;
-		let result = web::decode_response(&web_view, &url, &encoded_res)?;
+		let url = format!("{API_URL}{path}");
+
+		let result = {
+			let mut web_view = self.web_view.borrow_mut();
+			web::get_api_response(&mut web_view, &path, &url)?
+		};
+
 		let json: ChapterResponse = serde_json::from_str(&result)?;
 
 		let Some(result) = json.result else {
 			bail!("Missing chapter")
 		};
 
-		let base_url = result.pages.base_url.trim_end_matches('/');
-		Ok(result
-			.pages
-			.items
-			.into_iter()
-			.map(|page| {
-				let url = if page.url.starts_with("http") {
-					page.url
-				} else {
-					format!("{base_url}/{}", page.url.trim_start_matches('/'))
-				};
-				Page {
-					content: if let Some(s) = page.s {
-						let mut context = PageContext::new();
-						context.insert("s".into(), s.to_string());
-						context.insert("width".into(), page.width.to_string());
-						context.insert("height".into(), page.height.to_string());
-						PageContent::url_context(url, context)
-					} else {
-						PageContent::url(url)
-					},
-					..Default::default()
-				}
-			})
-			.collect())
+		let pages = images::build_page_list(self, &result.pages.base_url, result.pages.items)?;
+		if pages.is_empty() {
+			bail!("Comix returned an empty page list")
+		}
+		Ok(pages)
 	}
 }
 
 impl Home for Comix {
 	fn get_home(&self) -> Result<HomeLayout> {
-		// send basic layout
 		send_partial_result(&HomePartialResult::Layout(HomeLayout {
 			components: vec![
 				HomeComponent {
@@ -360,7 +358,7 @@ impl Home for Comix {
 			))?,
 		])
 		.try_into()
-		.expect("requests vec length should be 4");
+		.map_err(|_| error!("Comix home returned an unexpected response count"))?;
 
 		let [popular_res, follows_res, latest_res, recent_res] = responses;
 
@@ -480,11 +478,11 @@ impl ListingProvider for Comix {
 			"Trending Webtoon" => trending(vec!["manhua".into(), "manhwa".into()]),
 			"Trending Manga" => trending(vec!["manga".into()]),
 
-			"Most Recent Popular" => {
-				get_listing_page(&format!("{API_URL}/top?type=trending&days=1&limit=50"))
-			}
+			"Most Recent Popular" => get_listing_page(&format!(
+				"{API_URL}/manga/top?type=trending&days=1&limit=50"
+			)),
 			"Most Follows New Comics" => {
-				get_listing_page(&format!("{API_URL}/top?type=follows&days=1&limit=50"))
+				get_listing_page(&format!("{API_URL}/manga/top?type=follows&days=1&limit=50"))
 			}
 
 			"Latest Updates (Hot)" => get_listing_page(&format!(
@@ -500,48 +498,17 @@ impl ListingProvider for Comix {
 }
 
 impl ImageRequestProvider for Comix {
-	fn get_image_request(&self, url: String, _context: Option<PageContext>) -> Result<Request> {
-		Ok(Request::get(url)?.header("Referer", &format!("{BASE_URL}/")))
-	}
-}
-
-impl PageImageProcessor for Comix {
-	fn process_page_image(
+	fn get_image_request(
 		&self,
-		response: ImageResponse,
-		context: Option<PageContext>,
-	) -> Result<ImageRef> {
-		if let Some(context) = context {
-			if context.get("s").is_some_and(|s| s == "1") {
-				let Some(url) = response.request.url else {
-					bail!("Unable to get the image url")
-				};
-
-				let Some(width) = context.get("width").and_then(|s| s.parse::<f32>().ok()) else {
-					bail!("Unable to get the image width")
-				};
-
-				let Some(height) = context.get("height").and_then(|s| s.parse::<f32>().ok()) else {
-					bail!("Unable to get the image height")
-				};
-
-				let web_view = web::create_web_view()?;
-
-				let data_url = web::descramble_image(&web_view, width, height, url.as_ref())?;
-				let Some((_, base64_data)) = data_url.split_once(',') else {
-					bail!("Unable to get the raw image data")
-				};
-				let bytes: Vec<u8> = general_purpose::STANDARD
-					.decode(base64_data)
-					.or_else(|_| bail!("Invalid base64 data given"))?;
-
-				Ok(ImageRef::new(bytes.as_ref()))
-			} else {
-				Ok(response.image)
-			}
-		} else {
-			Ok(response.image)
+		url: String,
+		context: Option<aidoku::PageContext>,
+	) -> Result<Request> {
+		let mut request = Request::get(url)?.header("Referer", &format!("{BASE_URL}/"));
+		// Comix's CDN 404s s:1 images without Origin and 404s non-s:1 images with it.
+		if context.is_some_and(|c| c.get(images::PAGE_S_FLAG_CONTEXT_KEY).is_some()) {
+			request = request.header("Origin", BASE_URL);
 		}
+		Ok(request)
 	}
 }
 
@@ -555,7 +522,7 @@ impl NotificationHandler for Comix {
 
 impl DeepLinkHandler for Comix {
 	fn handle_deep_link(&self, url: String) -> Result<Option<DeepLinkResult>> {
-		let Some(path) = url.strip_prefix(BASE_URL) else {
+		let Some(path) = url.strip_prefix(&format!("{BASE_URL}/")) else {
 			return Ok(None);
 		};
 
@@ -590,8 +557,8 @@ register_source!(
 	Comix,
 	Home,
 	ListingProvider,
-	ImageRequestProvider,
 	PageImageProcessor,
+	ImageRequestProvider,
 	NotificationHandler,
 	DeepLinkHandler
 );

--- a/sources/en.comix/src/models.rs
+++ b/sources/en.comix/src/models.rs
@@ -18,7 +18,7 @@ where
 {
 	let value = serde_json::Value::deserialize(deserializer)?;
 
-	if let Some(items) = value.get("items") {
+	let mut result = if let Some(items) = value.get("items") {
 		let items: Vec<ComixManga> =
 			serde_json::from_value(items.clone()).map_err(serde::de::Error::custom)?;
 		let meta = value
@@ -34,7 +34,11 @@ where
 		Err(serde::de::Error::custom(
 			"Invalid MangaItems or Vec<ComixManga>",
 		))
-	}
+	}?;
+
+	// Comix can expose list entries without a usable title route key.
+	result.items.retain(|manga| !manga.hid.is_empty());
+	Ok(result)
 }
 
 impl From<SearchResponse> for MangaPageResult {
@@ -108,7 +112,6 @@ pub struct ChapterItems {
 #[derive(Deserialize)]
 pub struct TermItems {
 	pub items: Vec<Term>,
-	// pub pagination: Pagination,
 }
 
 #[derive(Deserialize)]
@@ -118,7 +121,7 @@ pub struct ComixManga {
 	pub title: String,
 	pub synopsis: Option<String>,
 	pub r#type: String,
-	pub poster: Poster,
+	pub poster: Option<Poster>,
 	pub status: String,
 	pub content_rating: ComixContentRating,
 	pub authors: Option<Vec<Term>>,
@@ -127,8 +130,6 @@ pub struct ComixManga {
 	pub tags: Option<Vec<Term>>,
 	pub latest_chapter: Option<f32>,
 	pub url: String,
-	// pub has_chapters: bool,
-	// pub chapter_updated_at_formatted: Option<String>,
 }
 
 #[derive(Deserialize, Default)]
@@ -184,14 +185,17 @@ impl ComixManga {
 impl From<ComixManga> for Manga {
 	fn from(value: ComixManga) -> Self {
 		let url = format!("{BASE_URL}/{}", value.url.trim_start_matches('/'));
+		let cover = value
+			.poster
+			.map(|poster| match settings::image_quality().as_str() {
+				"medium" => poster.medium,
+				"large" => poster.large,
+				_ => poster.medium,
+			});
 		Self {
 			key: value.hid,
 			title: value.title,
-			cover: match settings::image_quality().as_str() {
-				"medium" => Some(value.poster.medium),
-				"large" => Some(value.poster.large),
-				_ => Some(value.poster.medium),
-			},
+			cover,
 			artists: value
 				.artists
 				.map(|v| v.into_iter().map(|t| t.title).collect()),
@@ -247,24 +251,22 @@ impl ComixChapter {
 	pub fn created_at(&self) -> i64 {
 		helpers::parse_relative_date_string(&self.created_at_formatted)
 	}
-}
 
-impl From<ComixChapter> for Chapter {
-	fn from(value: ComixChapter) -> Self {
-		let created_at = value.created_at();
+	pub fn into_chapter(self) -> Chapter {
+		let created_at = self.created_at();
 		Chapter {
-			key: value.id.to_string(),
-			title: (!value.name.is_empty()).then_some(value.name),
-			chapter_number: Some(value.number),
+			key: self.id.to_string(),
+			title: (!self.name.is_empty()).then_some(self.name),
+			chapter_number: Some(self.number),
 			date_uploaded: Some(created_at),
-			scanlators: if let Some(group) = value.group {
+			scanlators: if let Some(group) = self.group {
 				Some(vec![group.name])
-			} else if value.is_official {
+			} else if self.is_official {
 				Some(vec!["Official".into()])
 			} else {
 				None
 			},
-			url: Some(format!("{BASE_URL}/{}", value.url.trim_start_matches('/'))),
+			url: Some(format!("{BASE_URL}/{}", self.url.trim_start_matches('/'))),
 			..Default::default()
 		}
 	}
@@ -303,8 +305,11 @@ pub struct ComixPages {
 #[derive(Deserialize)]
 pub struct ComixPage {
 	pub url: String,
+	#[serde(default)]
 	pub width: f32,
+	#[serde(default)]
 	pub height: f32,
+	#[serde(default)]
 	pub s: Option<i32>,
 }
 

--- a/sources/en.comix/src/web.rs
+++ b/sources/en.comix/src/web.rs
@@ -1,288 +1,594 @@
-// reference: https://github.com/nobottomline/extensions-source/blob/c8fe930f315f3baee23587559edfceab5e969202/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Signer.kt
 use crate::BASE_URL;
 use aidoku::{
 	Result,
-	alloc::string::String,
-	imports::{js::WebView, net::Request},
+	alloc::{string::String, vec::Vec},
+	helpers::uri::encode_uri_component,
+	imports::{js::WebView, net::Request, std::sleep},
 	prelude::*,
 };
-use regex::Regex;
 
-const GET_VMOBJ_JS: &str = "\
-const vmKey = Object.keys(window).find(key => key.startsWith('vm'));\
-const vmObj = window[vmKey];\
-if (!vmObj || typeof vmObj !== 'object' || vmObj === window) {\
-	return '';\
-}";
+// The reader imports signing/image helpers from a hashed `secure-*.js` module.
+// Find the import from the entry module; the install step below validates it.
+const DISCOVER_SECURITY_MODULE_JS: &str = r#"
+(() => {
+	try {
+		const HOME = "https://comix.to/";
+		const ORIGIN = new URL(HOME).origin;
+		const ENTRY_SELECTOR = "script[type='module'][src],link[rel~='modulepreload'][href]";
+		const SECURE_REF_RE = /["']([^"']*\/?secure-[^"']+\.js(?:\?[^"']*)?)["']/g;
 
-const JS_PATCHER: &str = "<head><script>window['originalGetImageData'] = HTMLCanvasElement.prototype.toDataURL;</script>";
+		const sameOriginUrl = (value, base = HOME) => {
+			try {
+				const url = new URL(value, base);
+				return url.origin === ORIGIN ? url.href : "";
+			} catch (_) { return ""; }
+		};
+		const fetchText = (url) => {
+			const req = new XMLHttpRequest();
+			req.open("GET", url, false);
+			req.withCredentials = true;
+			req.send(null);
+			if (req.status < 200 || req.status >= 300) throw new Error(`fetch ${url} failed: ${req.status}`);
+			return req.responseText || "";
+		};
+		const findEntry = (root, base) => {
+			const node = root.querySelector(ENTRY_SELECTOR);
+			return node ? sameOriginUrl(node.getAttribute("src") || node.getAttribute("href"), base) : "";
+		};
+		const findSecureModule = (code, base) => {
+			SECURE_REF_RE.lastIndex = 0;
+			let match;
+			while ((match = SECURE_REF_RE.exec(code))) {
+				const url = sameOriginUrl(match[1], base);
+				if (url) return url;
+			}
+			return "";
+		};
+
+		let entryUrl = findEntry(document, location.href);
+		let cfg = document.querySelector("meta[name='cfg']")?.getAttribute("content") || "";
+		if (!entryUrl || !cfg) {
+			const homepage = new DOMParser().parseFromString(fetchText(HOME), "text/html");
+			if (!entryUrl) entryUrl = findEntry(homepage, HOME);
+			if (!cfg) cfg = homepage.querySelector("meta[name='cfg']")?.getAttribute("content") || "";
+		}
+		if (!entryUrl) throw new Error("module entry not found");
+
+		const secureUrl = findSecureModule(fetchText(entryUrl), entryUrl);
+		if (!secureUrl) throw new Error("secure module import not found");
+		return JSON.stringify({ url: secureUrl, cfg });
+	} catch (e) {
+		return JSON.stringify({ error: e && e.message ? e.message : String(e) });
+	}
+})()
+"#;
+
+const INSTALL_SECURITY_HTML_TEMPLATE: &str = r#"<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<script>
+(() => {
+	const safeMessage = (value) => {
+		const text = value && value.message ? value.message : String(value);
+		return text.length > 160 ? `${text.slice(0, 160)}...` : text;
+	};
+	const setState = (state) => {
+		window.__aidokuComixInstallState = JSON.stringify({
+			ok: !!state.ok,
+			done: !!state.done,
+			stage: String(state.stage || "unknown"),
+			message: safeMessage(state.message || ""),
+			hasSigner: typeof window.__aidokuComixSigner === "function",
+			hasDecoder: typeof window.__aidokuComixDecodeResponse === "function",
+		});
+	};
+	const fail = (stage, message) => setState({ done: true, stage, message });
+	window.__aidokuComixSetInstallState = setState;
+	setState({ stage: "init", message: "install started" });
+
+	window.addEventListener("error", (e) => fail("module-load", e.message || "module script failed"));
+	window.addEventListener("unhandledrejection", (e) => fail("module-import", e.reason || "module import rejected"));
+
+	const cfg = __CFG_JSON__;
+	if (cfg) {
+		const meta = document.createElement("meta");
+		meta.name = "cfg";
+		meta.content = cfg;
+		document.head.appendChild(meta);
+	}
+
+	const securityUrl = __SECURITY_URL_JSON__;
+	const SIGNER_PROBE_PATHS = ["/manga/x/chapters", "/chapters/x"];
+	const TOKEN_RE = /^[A-Za-z0-9._~+/=-]{20,512}$/;
+	const SCRAMBLE_PROBE_WEBP_BASE64 = "UklGRogAAABXRUJQVlA4THwAAAAvY8AYALkyRPQ/NmLBZP7QnTFE9D/JQ1FsK9XroXTRJWHsoV0+OR+wfjOKGklS2sDikYL1/z4JJEohI0lSqSzBkr3ncc5BJm2TGtg5DSYJMHlV6RavB6hva0caC2k+JPlHTFDOkaZ3kvwjHtIMUPYnyT+iraCAT7kABDkA";
+
+	const isSignatureValue = (value, originalPath) =>
+		typeof value === "string" && value !== originalPath && TOKEN_RE.test(value);
+
+	const findSignatureParam = (config, originalPath) => {
+		const params = config && config.params && typeof config.params === "object" ? config.params : {};
+		for (const [key, value] of Object.entries(params)) {
+			if (isSignatureValue(value, originalPath)) return { key, value };
+		}
+		try {
+			const signedUrl = new URL(config && config.url || "", location.origin);
+			if (signedUrl.pathname === new URL(originalPath, location.origin).pathname) {
+				for (const [key, value] of signedUrl.searchParams.entries()) {
+					if (isSignatureValue(value, originalPath)) return { key, value };
+				}
+			}
+		} catch (_) {}
+		return null;
+	};
+
+	const captureInstaller = (fn) => {
+		let requestHandler = null;
+		let responseHandler = null;
+		const client = {
+			interceptors: {
+				request: { use: (h) => { requestHandler = h; } },
+				response: { use: (h) => { responseHandler = h; } },
+			},
+			defaults: { headers: { common: {} }, transformRequest: [], transformResponse: [] },
+		};
+		const result = fn(client);
+		if (result && typeof result.then === "function") return { error: "installer returned async result" };
+		if (typeof requestHandler !== "function") return null;
+		const supports = SIGNER_PROBE_PATHS.some((path) => {
+			const signed = requestHandler({ url: path, method: "get", params: {} }) || {};
+			return !!findSignatureParam(signed, path);
+		});
+		return supports ? { requestHandler, responseHandler } : null;
+	};
+
+	const installScrambleMapHelper = (security) => {
+		const probeBlob = () => {
+			const raw = atob(SCRAMBLE_PROBE_WEBP_BASE64);
+			const bytes = new Uint8Array(raw.length);
+			for (let i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
+			return new Blob([bytes], { type: "image/webp" });
+		};
+		const parseGrid = (grid) => {
+			const match = String(grid || "").match(/^(\d+)x(\d+)$/);
+			if (!match) throw new Error("invalid scramble grid");
+			const cols = Number(match[1]);
+			const rows = Number(match[2]);
+			if (cols < 1 || rows < 1 || cols > 20 || rows > 20) throw new Error("unsupported scramble grid");
+			return { cols, rows, total: cols * rows };
+		};
+		const isPermutation = (map, total) =>
+			Array.isArray(map) && map.length === total && new Set(map).size === total &&
+			map.every((v) => Number.isInteger(v) && v >= 0 && v < total);
+		const computeWithRenderer = async (renderer, seed, grid) => {
+			const { cols, rows, total } = parseGrid(grid);
+			const calls = [];
+			const originalFetch = window.fetch;
+			const originalDrawImage = CanvasRenderingContext2D.prototype.drawImage;
+			window.fetch = async () => new Response(probeBlob(), {
+				status: 200,
+				headers: {
+					"Content-Type": "image/webp",
+					"X-Scramble-Seed": String(seed),
+					"X-Scramble-Grid": String(grid),
+				},
+			});
+			CanvasRenderingContext2D.prototype.drawImage = function(...args) {
+				if (args.length >= 9 && typeof args[1] === "number") calls.push(args.slice(1, 9));
+			};
+			try {
+				const canvas = document.createElement("canvas");
+				canvas.width = 100;
+				canvas.height = 100;
+				const result = renderer("https://comix.to/__aidoku_scramble_probe.webp", canvas);
+				if (!result || typeof result.then !== "function") throw new Error("renderer did not return a promise");
+				await result;
+			} finally {
+				window.fetch = originalFetch;
+				CanvasRenderingContext2D.prototype.drawImage = originalDrawImage;
+			}
+			const cellWidth = Math.floor(100 / cols);
+			const cellHeight = Math.floor(100 / rows);
+			const map = [];
+			for (const [sx, sy, , , dx, dy] of calls) {
+				const source = Math.floor(sx / cellWidth) + Math.floor(sy / cellHeight) * cols;
+				const dest = Math.floor(dx / cellWidth) + Math.floor(dy / cellHeight) * cols;
+				if (source >= 0 && source < total && dest >= 0 && dest < total && map[source] === undefined) {
+					map[source] = dest;
+				}
+			}
+			if (!isPermutation(map, total)) throw new Error(`invalid tile map (${calls.length} calls)`);
+			return map;
+		};
+
+		let renderer = null;
+		let queue = Promise.resolve();
+		const states = (window.__aidokuComixScrambleMapState = {});
+		window.__aidokuComixStartScrambleMap = (id, seed, grid) => {
+			const key = String(id || "");
+			if (!key) return JSON.stringify({ ok: false, done: true, stage: "map-start", message: "missing id" });
+			states[key] = { ok: false, done: false, stage: "queued", message: "", map: [] };
+			queue = queue.then(async () => {
+				let lastError = "";
+				const candidates = renderer ? [renderer] : Object.values(security || {}).filter((v) => typeof v === "function");
+				for (const candidate of candidates) {
+					try {
+						const map = await computeWithRenderer(candidate, seed, grid);
+						renderer = candidate;
+						states[key] = { ok: true, done: true, stage: "ready", message: "", map };
+						return;
+					} catch (e) {
+						lastError = safeMessage(e);
+					}
+				}
+				states[key] = { ok: false, done: true, stage: "renderer-detect", message: lastError || "no scramble renderer matched", map: [] };
+			});
+			return JSON.stringify({ ok: true, done: false, stage: "queued", message: "" });
+		};
+		window.__aidokuComixReadScrambleMap = (id) => {
+			const key = String(id || "");
+			const state = states[key];
+			if (!state) return JSON.stringify({ ok: false, done: true, stage: "map-read", message: "request not found", map: [] });
+			if (state.done) delete states[key];
+			return JSON.stringify(state);
+		};
+	};
+
+	const installFromModule = (security) => {
+		let captured = null;
+		let lastError = "";
+		for (const value of Object.values(security || {})) {
+			if (typeof value !== "function") continue;
+			try {
+				const candidate = captureInstaller(value);
+				if (candidate && candidate.error) { lastError = candidate.error; continue; }
+				if (candidate) { captured = candidate; break; }
+			} catch (e) { lastError = safeMessage(e); }
+		}
+		if (!captured) return fail("installer-detect", `no signer installer matched (last=${lastError || "none"})`);
+
+		window.__aidokuComixSigner = (path) => {
+			const signed = captured.requestHandler({ url: path, method: "get", params: {} }) || {};
+			if (signed && typeof signed.then === "function") return "";
+			const param = findSignatureParam(signed, path);
+			return param ? JSON.stringify(param) : "";
+		};
+
+		if (typeof captured.responseHandler === "function") {
+			window.__aidokuComixDecodeResponse = (url, encodedText) => {
+				const raw = typeof encodedText === "string" ? JSON.parse(encodedText) : encodedText;
+				const decoded = captured.responseHandler({
+					data: raw,
+					status: 200,
+					statusText: "",
+					headers: { "x-enc": "1" },
+					config: { url, method: "get", baseURL: "/api/v1" },
+					request: {},
+				}) || { data: null };
+				if (decoded && typeof decoded.then === "function") return "error: decoder returned async result";
+				return JSON.stringify({ result: decoded && decoded.data });
+			};
+		}
+		installScrambleMapHelper(security);
+
+		try {
+			const probe = window.__aidokuComixSigner("/manga/x/chapters");
+			const parsed = probe ? JSON.parse(probe) : null;
+			if (!parsed || typeof parsed.key !== "string" || typeof parsed.value !== "string") {
+				return fail("wrapper-check", "signer wrapper did not return a token-shaped value");
+			}
+		} catch (e) {
+			return fail("wrapper-check", safeMessage(e));
+		}
+		setState({ ok: true, done: true, stage: "ready", message: "ready" });
+	};
+
+	try {
+		const importResult = import(securityUrl);
+		if (!importResult || typeof importResult.then !== "function") {
+			fail("module-import", "dynamic import did not return a promise");
+			return;
+		}
+		importResult.then(installFromModule, (error) => fail("module-import", safeMessage(error)));
+	} catch (e) {
+		fail("module-import", safeMessage(e));
+	}
+})();
+</script>
+</head>
+<body></body>
+</html>"#;
+
+const READ_INSTALL_STATE_JS: &str = r#"
+(() => {
+	const state = window.__aidokuComixInstallState;
+	if (typeof state === "string") return state;
+	return JSON.stringify({
+		ok: false,
+		done: false,
+		stage: "state-read",
+		message: "install state missing",
+		hasSigner: typeof window.__aidokuComixSigner === "function",
+		hasDecoder: typeof window.__aidokuComixDecodeResponse === "function",
+	});
+})()
+"#;
+
+const EMPTY_WEBVIEW_HTML: &str =
+	r#"<!doctype html><html><head><meta charset="utf-8"></head><body></body></html>"#;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ApiResponseKind {
+	PlainJson,
+	EncodedJson,
+	Other,
+}
 
 pub struct ComixWebView {
 	web_view: WebView,
-	installer_fn: Option<String>,
-	descrambler_fn: Option<String>,
+}
+
+pub fn get_api_response(
+	web_view: &mut Option<ComixWebView>,
+	path: &str,
+	url: &str,
+) -> Result<String> {
+	let mut bodies = get_api_responses(web_view, path, &[url])?;
+	bodies
+		.pop()
+		.ok_or_else(|| error!("Comix signed response missing"))
+}
+
+/// Fetches all `urls` (which share one API `path`) in parallel: signs the path
+/// once, applies that signature to every URL, then sends them all via
+/// `Request::send_all`. Decoding stays sequential because WebView eval can't
+/// run concurrently.
+pub fn get_api_responses(
+	web_view: &mut Option<ComixWebView>,
+	path: &str,
+	urls: &[&str],
+) -> Result<Vec<String>> {
+	if urls.is_empty() {
+		return Ok(Vec::new());
+	}
+	let web_view_ref = get_or_create_web_view(web_view)?;
+	let (key, value) = match get_signature(web_view_ref, path) {
+		Ok(signature) => signature,
+		Err(error) => {
+			*web_view = None;
+			return Err(error);
+		}
+	};
+
+	let mut signed_urls = Vec::with_capacity(urls.len());
+	let mut requests = Vec::with_capacity(urls.len());
+	for &url in urls {
+		let signed_url = append_query_param(url, &key, &value);
+		requests.push(Request::get(&signed_url)?);
+		signed_urls.push(signed_url);
+	}
+
+	let responses = Request::send_all(requests);
+
+	let mut bodies = Vec::with_capacity(urls.len());
+	for (response_result, signed_url) in responses.into_iter().zip(signed_urls.iter()) {
+		let response = response_result?;
+		let status = response.status_code();
+		let body = response.get_string()?;
+		bodies.push(match response_kind(&body) {
+			ApiResponseKind::PlainJson => body,
+			ApiResponseKind::EncodedJson => decode_response(web_view_ref, signed_url, &body)?,
+			ApiResponseKind::Other => {
+				*web_view = None;
+				bail!("Comix signed response did not include result data (status={status})")
+			}
+		});
+	}
+	Ok(bodies)
 }
 
 pub fn create_web_view() -> Result<ComixWebView> {
 	let web_view = WebView::new();
-	web_view.load_html_blocking(
-		Request::get(BASE_URL)?
-			.string()?
-			.replace("<head>", JS_PATCHER)
-			.as_str(),
-		Some(BASE_URL),
-	)?;
-	let mut comix_web_view = ComixWebView {
-		web_view,
-		installer_fn: None,
-		descrambler_fn: None,
-	};
-	if find_functions(&mut comix_web_view).is_err() {
-		find_secure_module_src(&mut comix_web_view)?;
-		find_functions(&mut comix_web_view)?;
-	}
-	Ok(comix_web_view)
+	// The discover script does its own homepage fetch when the empty doc has
+	// no module entry, so no Rust-side retry is needed.
+	web_view.load_html_blocking(EMPTY_WEBVIEW_HTML, Some(BASE_URL))?;
+	install_security_helpers(&web_view)?;
+	Ok(ComixWebView { web_view })
 }
 
-fn find_secure_module_src(web_view: &mut ComixWebView) -> Result<()> {
-	let main_module_src = Request::get(BASE_URL)?
-		.html()?
-		.select("head > script[type=\"module\"][src*=\"main\"]")
-		.and_then(|e| e.first())
-		.and_then(|e| e.attr("src"))
-		.ok_or(error!("Main module not found"))?;
-	if let Some(js_asset_path_index) = main_module_src.rfind("/") {
-		let js_asset_path = &main_module_src[0..js_asset_path_index + 1];
-		let secure_script_regex = Regex::new("(secure-[A-Za-z0-9-_]+?\\.js)").unwrap();
-		let main_module_contents =
-			Request::get(format!("{BASE_URL}{main_module_src}"))?.string()?;
-		if let Some(secure_script_path) = secure_script_regex
-			.captures(main_module_contents.as_str())
-			.and_then(|captures| captures.get(1).map(|m| m.as_str()))
-		{
-			web_view.web_view.eval(&format!(
-				"(() => {{
-				import('{BASE_URL}{js_asset_path}{secure_script_path}')
-					.then((m) => window['vm'] = m)
-					.catch((e) => window['vm'] = {{}});
-				return '';
-			}})()"
-			))?;
-			while web_view
-				.web_view
-				.eval("(() => { return window['vm'] == null ? 'true' : 'false'; })()")?
-				== "true"
-			{}
-			Ok(())
-		} else {
-			bail!("Secure module not found");
+fn get_or_create_web_view(web_view: &mut Option<ComixWebView>) -> Result<&ComixWebView> {
+	if web_view.is_none() {
+		*web_view = Some(create_web_view()?);
+	}
+	Ok(web_view.as_ref().expect("just initialized"))
+}
+
+fn install_security_helpers(web_view: &WebView) -> Result<()> {
+	let raw = web_view.eval(DISCOVER_SECURITY_MODULE_JS)?;
+	let discovery: serde_json::Value = serde_json::from_str(&raw)
+		.map_err(|_| error!("Failed to discover Comix security module: invalid result"))?;
+	if let Some(error) = json_str(&discovery, "error") {
+		bail!("Failed to discover Comix security module: {error}")
+	}
+	let security_url = json_str(&discovery, "url")
+		.ok_or_else(|| error!("Failed to discover Comix security module: missing URL"))?;
+	let cfg = json_str(&discovery, "cfg").unwrap_or_default();
+
+	let html = INSTALL_SECURITY_HTML_TEMPLATE
+		.replace(
+			"__SECURITY_URL_JSON__",
+			&serde_json::to_string(security_url)?,
+		)
+		.replace("__CFG_JSON__", &serde_json::to_string(cfg)?);
+	web_view.load_html_blocking(&html, Some(BASE_URL))?;
+	wait_for_security_install(web_view)
+}
+
+fn wait_for_security_install(web_view: &WebView) -> Result<()> {
+	let mut last_stage = String::from("unknown");
+	let mut last_message = String::new();
+
+	for attempt in 0..=15 {
+		let raw_state = web_view.eval(READ_INSTALL_STATE_JS)?;
+		let state: serde_json::Value = serde_json::from_str(&raw_state)
+			.map_err(|_| error!("Comix install state was not JSON"))?;
+
+		let done = json_bool(&state, "done");
+		let ok = json_bool(&state, "ok");
+		let has_signer = json_bool(&state, "hasSigner");
+		last_stage = json_str(&state, "stage").unwrap_or("unknown").into();
+		last_message = json_str(&state, "message").unwrap_or("").into();
+
+		if done {
+			if ok && has_signer {
+				return Ok(());
+			}
+			bail!("Failed to install Comix security helpers: stage={last_stage}: {last_message}");
 		}
-	} else {
-		bail!("Invalid path")
+		if (3..15).contains(&attempt) {
+			sleep(1);
+		}
 	}
+	bail!("Comix security helper install timed out: stage={last_stage}: {last_message}")
 }
 
-fn find_functions(web_view: &mut ComixWebView) -> Result<()> {
+fn json_bool(value: &serde_json::Value, key: &str) -> bool {
+	value.get(key).and_then(|v| v.as_bool()).unwrap_or(false)
+}
+
+fn json_str<'a>(value: &'a serde_json::Value, key: &str) -> Option<&'a str> {
+	value.get(key).and_then(|v| v.as_str())
+}
+
+/// Signs `path` once via the JS signer wrapper. The signature is a pure
+/// function of the path, so paginated callers reuse it across every URL.
+fn get_signature(web_view: &ComixWebView, path: &str) -> Result<(String, String)> {
+	let path_json = serde_json::to_string(path)?;
 	let result = web_view.web_view.eval(&format!(
-		"(() => {{
-			try {{
-				{GET_VMOBJ_JS}
-				let fnames = Object.keys(vmObj);
-				let inst = '', desc = '';
-				for (let j = 0; j < fnames.length; j++) {{
-					let fn = vmObj[fnames[j]];
-					if (typeof fn !== 'function') continue;
-					let ref = 'window[' + JSON.stringify(vmKey) + '].' + fnames[j];
-					if (!inst) {{
-						try {{
-							let got = false;
-							fn({{
-								interceptors: {{
-									request: {{ use: function() {{}} }},
-									response: {{ use: function() {{ got = true; }} }}
-								}},
-								defaults: {{
-									headers: {{ common: {{}} }},
-									transformRequest: [],
-									transformResponse: []
-								}}
-							}});
-							if (got) inst = ref;
-						}} catch (e) {{}}
-					}}
-					if (!desc) {{
-						if (fn.constructor.name === 'AsyncFunction') {{
-							desc = ref;
-						}}
-					}}
-				}}
-				return inst + '||' + desc
-			}} catch(e) {{}}
-			return '';
-		}})()",
+		"(() => {{ try {{ \
+			if (typeof window.__aidokuComixSigner !== 'function') return ''; \
+			return window.__aidokuComixSigner({path_json}); \
+		}} catch (_) {{ return ''; }} }})()"
 	))?;
-	let Some((installer_expr, descrambler_expr)) = result.split_once("||") else {
-		bail!("Failed to find installer and descrambler functions")
-	};
-	if installer_expr.is_empty() {
-		bail!("Failed to find installer function");
-	};
-	if descrambler_expr.is_empty() {
-		bail!("Failed to find descrambler function");
-	};
-	web_view.installer_fn = Some(installer_expr.into());
-	web_view.descrambler_fn = Some(descrambler_expr.into());
-	Ok(())
-}
 
-/// * `path`: API path, e.g. "/manga/some-hash/chapters"
-pub fn get_token(web_view: &ComixWebView, path: &str) -> Result<String> {
-	let Some(installer_fn) = web_view.installer_fn.as_ref() else {
-		bail!("Missing installer function")
-	};
-	let token = web_view.web_view.eval(&format!(
-		"(() => {{
-			try {{
-				{GET_VMOBJ_JS}
-				let captured = {{ req: null, res: null }};
-				{installer_fn}({{
-					interceptors: {{
-						request: {{
-							use: function (fn) {{ captured.req = fn; }},
-						}},
-						response: {{
-							use: function (fn) {{ captured.res = fn; }},
-						}},
-					}},
-					defaults: {{
-						headers: {{ common: {{}} }},
-						transformRequest: [],
-						transformResponse: []
-					}}
-				}});
-				return captured.req({{ url: '{path}', method: 'GET' }}).params['_'];
-			}} catch(e) {{
-				return '';
-			}}
-		}})()"
-	))?;
-	if token.is_empty() {
-		bail!("Failed to fetch token")
+	let invalid = || error!("Comix signer wrapper returned an invalid signature");
+	if result.is_empty() {
+		return Err(invalid());
 	}
-	Ok(token)
+	let payload: serde_json::Value = serde_json::from_str(&result).map_err(|_| invalid())?;
+	let key = json_str(&payload, "key").ok_or_else(invalid)?;
+	let value = json_str(&payload, "value").ok_or_else(invalid)?;
+	if key.is_empty() || value.is_empty() {
+		return Err(invalid());
+	}
+	Ok((key.into(), value.into()))
 }
 
-pub fn decode_response(web_view: &ComixWebView, url: &str, encoded_res: &str) -> Result<String> {
-	let Some(installer_fn) = web_view.installer_fn.as_ref() else {
-		bail!("Missing installer function")
-	};
-
-	let json = serde_json::from_str::<serde_json::Value>(encoded_res)
-		.map_err(|_| error!("Invalid api response"))?;
-	let is_encoded = match json {
-		serde_json::Value::Object(ref map) => map.contains_key("e"),
-		_ => false,
-	};
-	if !is_encoded {
-		return Ok(encoded_res.into());
-	};
-
-	let encoded_res_escaped = encoded_res.replace("'", "\\'");
+fn decode_response(web_view: &ComixWebView, url: &str, encoded_res: &str) -> Result<String> {
+	let url = serde_json::to_string(url)?;
+	let encoded_res = serde_json::to_string(encoded_res)?;
 	let result = web_view.web_view.eval(&format!(
-		"(() => {{
-			try {{
-				{GET_VMOBJ_JS}
-				let captured = {{ req: null, res: null }};
-				{installer_fn}({{
-					interceptors: {{
-						request: {{
-							use: function (fn) {{ captured.req = fn; }},
-						}},
-						response: {{
-							use: function (fn) {{ captured.res = fn; }},
-						}},
-					}},
-					defaults: {{
-						headers: {{ common: {{}} }},
-						transformRequest: [],
-						transformResponse: []
-					}}
-				}});
-				if (!captured.res) {{
-					return 'error: could not capture response handler';
-				}}
-
-				let raw = JSON.parse('{encoded_res_escaped}');
-				let fakeResp = {{
-					data: raw,
-					status: 200,
-					statusText: '',
-					headers: {{
-						'x-enc': '1',
-					}},
-					config: {{ url: '{url}', method: 'get', baseURL: '/api/v1' }},
-					request: {{}},
-				}};
-				let decoded = captured.res(fakeResp);
-				return JSON.stringify({{ result: decoded && decoded.data }});
-			}} catch(e) {{
-				return 'error: ' + e;
-			}}
-		}})()",
+		"(() => {{ try {{ \
+			if (typeof window.__aidokuComixDecodeResponse !== 'function') return 'error: decoder not installed'; \
+			return window.__aidokuComixDecodeResponse({url}, {encoded_res}); \
+		}} catch(e) {{ return 'error: ' + e; }} }})()"
 	))?;
 	if result.starts_with("error:") {
-		bail!("{result}");
-	} else if result.is_empty() {
-		bail!("Failed to fetch token")
+		bail!("Failed to decode Comix response: {result}");
+	}
+	if result.is_empty() || response_kind(&result) == ApiResponseKind::Other {
+		bail!("Comix decoder returned an unexpected response shape")
 	}
 	Ok(result)
 }
 
-pub fn descramble_image(
-	web_view: &ComixWebView,
-	width: f32,
-	height: f32,
-	url: &str,
-) -> Result<String> {
-	let Some(descrambler_fn) = web_view.descrambler_fn.as_ref() else {
-		bail!("Missing descramble function")
+pub fn get_scramble_map(
+	web_view: &mut Option<ComixWebView>,
+	seed: &str,
+	grid: &str,
+) -> Result<Vec<usize>> {
+	let web_view = get_or_create_web_view(web_view)?;
+	let request_id = serde_json::to_string(&format!("{seed}:{grid}"))?;
+	let seed = serde_json::to_string(seed)?;
+	let grid = serde_json::to_string(grid)?;
+
+	let start = scramble_map_eval(
+		web_view,
+		&format!("window.__aidokuComixStartScrambleMap({request_id}, {seed}, {grid})"),
+	)?;
+	if json_bool(&start, "done") && !json_bool(&start, "ok") {
+		bail!(
+			"Failed to start Comix image descrambler: {}",
+			scramble_error(&start)
+		);
+	}
+
+	for attempt in 0..=8 {
+		let state = scramble_map_eval(
+			web_view,
+			&format!("window.__aidokuComixReadScrambleMap({request_id})"),
+		)?;
+		if json_bool(&state, "done") {
+			if !json_bool(&state, "ok") {
+				bail!(
+					"Failed to build Comix image descrambler map: {}",
+					scramble_error(&state)
+				);
+			}
+			return state
+				.get("map")
+				.and_then(|v| v.as_array())
+				.ok_or_else(|| error!("Comix image descrambler returned no tile map"))?
+				.iter()
+				.map(|v| {
+					v.as_u64().map(|n| n as usize).ok_or_else(|| {
+						error!("Comix image descrambler returned an invalid tile map")
+					})
+				})
+				.collect();
+		}
+		if attempt >= 2 {
+			sleep(1);
+		}
+	}
+
+	bail!("Timed out while building Comix image descrambler map")
+}
+
+fn scramble_map_eval(web_view: &ComixWebView, body: &str) -> Result<serde_json::Value> {
+	let raw = web_view.web_view.eval(&format!(
+		"(() => {{ try {{ return {body}; }} \
+		catch (e) {{ return JSON.stringify({{ done: true, ok: false, message: String(e) }}); }} }})()"
+	))?;
+	serde_json::from_str(&raw)
+		.map_err(|_| error!("Comix image descrambler returned an invalid WebView result"))
+}
+
+fn scramble_error(value: &serde_json::Value) -> String {
+	let stage = json_str(value, "stage").unwrap_or("unknown");
+	let message = json_str(value, "message").unwrap_or("");
+	format!("stage={stage}: {message}")
+}
+
+fn response_kind(body: &str) -> ApiResponseKind {
+	let Ok(serde_json::Value::Object(map)) = serde_json::from_str::<serde_json::Value>(body) else {
+		return ApiResponseKind::Other;
 	};
 
-	web_view.web_view.eval(&format!(
-		"(() => {{
-		const canvas = document.createElement('canvas');
-		canvas.width = {width};
-		canvas.height = {height};
-
-		window['TEMP_CANVAS'] = canvas;
-		window['TEMP_STATE'] = {{ isDone: false, error: null }}
-
-		{GET_VMOBJ_JS}
-		{descrambler_fn}('{url}', canvas)
-			.then(() => window['TEMP_STATE'].isDone = true)
-			.catch((e) => {{ window['TEMP_STATE'].isDone = true; window['TEMP_STATE'].error = e }});
-
-		return '';
-	}})()"
-	))?;
-
-	while web_view
-		.web_view
-		.eval("(() => { return window['TEMP_STATE'].isDone ? 'true' : 'false'; })()")?
-		== "false"
-	{}
-
-	let result = web_view.web_view.eval(
-		"(() => {{
-		if (window['TEMP_STATE'].error) return '';
-		const data = window['originalGetImageData'].call(window['TEMP_CANVAS']);
-		return data;
-	}})()",
-	)?;
-
-	if result.is_empty() {
-		bail!("Failed to descramble image")
+	if map.contains_key("e") {
+		ApiResponseKind::EncodedJson
+	} else if map.contains_key("result") {
+		ApiResponseKind::PlainJson
 	} else {
-		Ok(result)
+		ApiResponseKind::Other
 	}
+}
+
+fn append_query_param(url: &str, key: &str, value: &str) -> String {
+	let separator = if url.contains('?') { '&' } else { '?' };
+	format!(
+		"{url}{separator}{}={}",
+		encode_uri_component(key),
+		encode_uri_component(value)
+	)
 }


### PR DESCRIPTION
## Summary

Updates the Comix source for current site behavior:

- uses the module-based reader/security helper flow for chapter-list and chapter-page requests;
- supports scrambled page images reported in #533;
- handles search results where `poster` is `null`;
- omits result entries without a usable title route key.

This overlaps with #532, but differs in image handling: normal pages are untouched, only pages marked `s:1` can enter descrambling, and image processing uses prepared per-page context rather than creating or using a WebView while rendering each image.

## Reader Flow

The previous source depended on helper functions exposed through a `window.vm*` object. Current Comix reader behavior exposes the required signing, response decoding, and scramble-map functionality through module-based frontend code.

Chapter-list and chapter-page requests now use that helper path directly. Because module initialization is asynchronous inside the WebView, the source stores a small JSON install state and polls it with bounded waits rather than expecting `eval` to await a Promise.

Plain JSON response handling remains supported where returned by the API.

## Scrambled Images

Some Comix pages are marked with `s: 1` and use scrambled `/si/...` or `/sii/...` image routes.

- Normal pages are returned unchanged.
- Each scrambled-marked page checks its own `/i/...` counterpart and uses the clean route as a fast path when it is available.
- The clean-route check remains page-specific because Comix can expose `/i/...` for some marked pages while neighboring marked pages in the same chapter still require `/si/...` processing.
- When `/i/...` is unavailable, the source prepares per-page tile-map context through the reader/security helper and reassembles only affected images through Aidoku's `PageImageProcessor`.
- The processor performs local canvas work only; it does not call the WebView or helper asynchronously while rendering images.
- If descrambling cannot be prepared or processing fails, the raw image is returned instead of failing the entire chapter.
- Unknown future scrambled route names are not guessed as clean `/i/...` routes.

The image-specific implementation is isolated in `images.rs` to keep the main source flow readable.

## Response Parsing

Comix search results can contain `poster: null`. These results now parse successfully and display without a cover rather than failing the result list.

Comix can also return entries without a usable title route key. Those entries are omitted rather than producing an error when opened.

No search ranking changes are intended.

## Validation

Passed:

- `cargo fmt --check`
- `cargo test`
- `cargo check`
- `cargo clippy -- -D warnings`
- `aidoku package`
- `aidoku verify package.aix`
- `git diff --check`

On-device testing passed for normal chapters, recent chapters requiring descrambling, older affected chapters using the clean `/i/` path, chapters with mixed per-page clean-route availability, nullable-poster search results, Preload Pages, and valid titles with no uploaded chapters.

## Retest Checklist

- Open a normal older chapter.
- Open a recently uploaded chapter containing scrambled pages.
- Verify affected scrambled pages from #533 render correctly.
- Verify a chapter with mixed clean-route availability does not show blank pages.
- Verify reading with Preload Pages enabled and disabled.
- Search for a result set containing a title without a poster, such as `friends`, and confirm results display.
- Open a valid series with no uploaded chapters and confirm it loads normally.

## Remaining Risk

This source follows Comix's current module, API, and image-scrambling behavior. Further site changes may require source adjustments.
