### PR TITLE
feat(en.freewebnovel): add markdown

### DIFF
--- a/sources/en.freewebnovel/res/source.json
+++ b/sources/en.freewebnovel/res/source.json
@@ -8,6 +8,6 @@
 		"languages": [
 			"en"
 		],
-		"minAppVersion": "0.8.0"
+		"minAppVersion": "0.8.3"
 	}
 }

--- a/sources/en.freewebnovel/res/source.json
+++ b/sources/en.freewebnovel/res/source.json
@@ -2,7 +2,7 @@
 	"info": {
 		"id": "en.freewebnovel",
 		"name": "FreeWebNovel",
-		"version": 1,
+		"version": 2,
 		"url": "https://freewebnovel.com",
 		"contentRating": 1,
 		"languages": [

--- a/sources/en.freewebnovel/res/source.json
+++ b/sources/en.freewebnovel/res/source.json
@@ -8,6 +8,6 @@
 		"languages": [
 			"en"
 		],
-		"minAppVersion": "0.8"
+		"minAppVersion": "0.8.0"
 	}
 }

--- a/sources/en.freewebnovel/src/helpers.rs
+++ b/sources/en.freewebnovel/src/helpers.rs
@@ -3,7 +3,7 @@ use aidoku::{
 	Chapter, ContentRating, Manga, MangaStatus, Result,
 	alloc::{String, Vec, string::ToString},
 	imports::{
-		html::{Document, Element},
+		html::{Document, Element, Kind},
 		net::Request,
 	},
 	prelude::*,
@@ -128,31 +128,114 @@ pub fn extract_chapters(html: &Document) -> Vec<Chapter> {
 		.collect()
 }
 
-pub fn extract_chapter_text(html: &Document) -> Result<String> {
-	let container_selector = "div.txt";
-	let mut parts = Vec::new();
+fn convert_element_to_markdown(element: &Element, output: &mut String) {
+	let nodes = element.child_nodes();
 
-	if let Some(container) = html.select_first(container_selector)
-		&& let Some(elms) = container.select("p, h4")
-	{
-		for part in elms {
-			// Remove ADs
-			if let Some(thing) = part.select("subtxt") {
-				for ad in thing {
-					ad.remove();
+	for node in nodes {
+		match node.kind() {
+			Kind::TextNode => {
+				if let Some(text) = node.text() {
+					if text.len() >= 3 && text.replace("-", "").trim().is_empty() {
+						output.push_str(&text);
+					} else {
+						output.push_str(&text.replace("*", r"\*").replace("-", r"\-"));
+					}
 				}
 			}
-			if let Some(text) = part.text()
-				&& !text.is_empty()
-			{
-				parts.push(text.to_string());
+			Kind::Element => {
+				let el = Element::try_from(node).unwrap();
+				convert_tag_to_markdown(&el, output);
 			}
+			_ => (),
 		}
 	}
-	if parts.is_empty() {
+}
+
+fn convert_tag_to_markdown(element: &Element, output: &mut String) {
+	let tag = element.tag_name().unwrap_or_default();
+
+	match tag.as_str() {
+		"p" => {
+			convert_element_to_markdown(element, output);
+			output.push_str("\n\n");
+		}
+		"br" => {
+			output.push_str("  \n");
+		}
+		"h1" => {
+			output.push_str("# ");
+			convert_element_to_markdown(element, output);
+			output.push_str("\n\n");
+		}
+		"h2" => {
+			output.push_str("## ");
+			convert_element_to_markdown(element, output);
+			output.push_str("\n\n");
+		}
+		"h3" => {
+			output.push_str("### ");
+			convert_element_to_markdown(element, output);
+			output.push_str("\n\n");
+		}
+		"h4" => {
+			output.push_str("#### ");
+			convert_element_to_markdown(element, output);
+			output.push_str("\n\n");
+		}
+		"h5" => {
+			output.push_str("##### ");
+			convert_element_to_markdown(element, output);
+			output.push_str("\n\n");
+		}
+		"h6" => {
+			output.push_str("###### ");
+			convert_element_to_markdown(element, output);
+			output.push_str("\n\n");
+		}
+		"strong" | "b" => {
+			output.push_str("**");
+			convert_element_to_markdown(element, output);
+			output.push_str("**");
+		}
+		"em" | "i" => {
+			output.push('*');
+			convert_element_to_markdown(element, output);
+			output.push('*');
+		}
+		"u" => {
+			output.push_str("__");
+			convert_element_to_markdown(element, output);
+			output.push_str("__");
+		}
+		"s" | "strike" | "del" => {
+			output.push_str("~~");
+			convert_element_to_markdown(element, output);
+			output.push_str("~~");
+		}
+		_ => {
+			convert_element_to_markdown(element, output);
+		}
+	}
+}
+
+pub fn extract_chapter_text(html: &Document) -> Result<String> {
+	let mut text = String::new();
+
+	if let Some(container) = html.select_first("#article") {
+		// Remove ADs
+		if let Some(ads) = container.select("subtxt") {
+			ads.for_each(Element::remove);
+		}
+		if let Some(things) = container.select("div") {
+			things.for_each(Element::remove);
+		}
+		convert_element_to_markdown(&container, &mut text);
+		text = text.replace("****", "");
+	}
+	if text.is_empty() {
 		bail!("chapter text not found");
 	}
-	Ok(parts.join("\n\n"))
+	Ok(text.to_string())
 }
 
 pub fn parse_search_results(html: &Document) -> Vec<Manga> {

--- a/sources/en.freewebnovel/src/helpers.rs
+++ b/sources/en.freewebnovel/src/helpers.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::needless_pass_by_value)]
 use crate::BASE_URL;
 use aidoku::{
 	Chapter, ContentRating, Manga, MangaStatus, Result,
@@ -106,20 +105,22 @@ pub fn extract_chapters(html: &Document) -> Vec<Chapter> {
 			let url = link.attr("abs:href")?;
 			let (_, chapter_key) = parse_novel_and_chapter(&url)?;
 			let chapter_key = chapter_key?;
-			let title = link.text()?;
-			let chapter_number = parse_chapter_number(&title)?;
-			let title = match title.strip_prefix(&format!("Chapter {chapter_number}")) {
-				Some(rest) => rest
-					.trim()
-					.strip_prefix(':')
-					.or_else(|| rest.trim().strip_prefix('-'))
-					.map_or_else(|| rest.trim().to_string(), |t| t.trim().to_string()),
-				None => title,
+			let mut title = link.text()?;
+			let chapter_number = parse_chapter_number(&title);
+			if let Some(chapter_number) = chapter_number {
+				title = match title.strip_prefix(&format!("Chapter {chapter_number}")) {
+					Some(rest) => rest
+						.trim()
+						.strip_prefix(':')
+						.or_else(|| rest.trim().strip_prefix('-'))
+						.map_or_else(|| rest.trim().to_string(), |t| t.trim().to_string()),
+					None => title,
+				};
 			};
 			Some(Chapter {
 				key: chapter_key,
 				title: { if !title.is_empty() { Some(title) } else { None } },
-				chapter_number: chapter_number.into(),
+				chapter_number,
 				url: Some(url),
 				..Default::default()
 			})


### PR DESCRIPTION
I mostly took the code from `templates/libgroup/converters/html_to_markdown.rs`.

~~One thing I am unsure about is an issue the AI brought up regarding the logic:~~

> ~~Inline text order can be corrupted in markdown conversion
In [helpers.rs:204], convert_children_to_markdown appends element.own_text before recursing into children. For mixed-content nodes like p with text + nested strong + trailing text, this can reorder output (child text may end up after trailing plain text). \[...\] this outputs "prefix suffix **bold**" instead of "prefix **bold** suffix".~~

~~I am not a 100% the AI and me are understanding `element.own_text()` correctly, as tooltip for that one is rather lackluster, but if we are understanding that correctly, that should at least be given a thought.~~

RE: L233: adjacent bold boundaries would mess up each other / not get rendered right

Supersedes #546 (Fixes Chapters without a number like `Prologue` getting lost)