### PR TITLE
fix(en.comix): not using canvas directly anymore

### DIFF
--- a/sources/en.comix/res/source.json
+++ b/sources/en.comix/res/source.json
@@ -2,7 +2,7 @@
 	"info": {
 		"id": "en.comix",
 		"name": "Comix",
-		"version": 18,
+		"version": 19,
 		"url": "https://comix.to",
 		"contentRating": 1,
 		"languages": ["en"]

--- a/sources/en.comix/src/web.rs
+++ b/sources/en.comix/src/web.rs
@@ -264,9 +264,22 @@ pub fn descramble_image(
 		window['TEMP_CANVAS'] = canvas;
 		window['TEMP_STATE'] = {{ isDone: false, error: null }}
 
+		const controller = new AbortController();
+		const signal = controller.signal;
+
 		{GET_VMOBJ_JS}
-		{descrambler_fn}('{url}', canvas)
-			.then(() => window['TEMP_STATE'].isDone = true)
+		{descrambler_fn}('{url}', signal)
+			.then((data) => {{
+				const url = URL.createObjectURL(data);
+				const image = new Image();
+				image.src = url;
+				image.onload = () => {{
+					URL.revokeObjectURL(url);
+					const ctx = canvas.getContext('2d');
+					ctx.drawImage(image, 0, 0);
+					window['TEMP_STATE'].isDone = true;
+				}}
+			}})
 			.catch((e) => {{ window['TEMP_STATE'].isDone = true; window['TEMP_STATE'].error = e }});
 
 		return '';


### PR DESCRIPTION
Comix changed it to output to a raw blob which can only be used with Image API. So yep this does exactly that and redirect the output to my canvas so it can continue to work.

Fixes #553 