### PR TITLE
fix(multi.mangadotnet): missing scanlator group names

### DIFF
--- a/sources/multi.mangadotnet/res/source.json
+++ b/sources/multi.mangadotnet/res/source.json
@@ -2,7 +2,7 @@
 	"info": {
 		"id": "multi.mangadotnet",
 		"name": "Mangadotnet",
-		"version": 1,
+		"version": 2,
 		"url": "https://mangadot.net",
 		"contentRating": 1,
 		"languages": [

--- a/sources/multi.mangadotnet/src/models.rs
+++ b/sources/multi.mangadotnet/src/models.rs
@@ -231,7 +231,10 @@ impl From<MangaChapter> for Chapter {
 			chapter_number: Some(value.chapter_number),
 			volume_number: value.volume_number,
 			date_uploaded: date,
-			scanlators: value.scanlator_name.map(|name| vec![name]),
+			scanlators: value
+				.group_name
+				.or(value.scanlator_name)
+				.map(|name| vec![name]),
 			url: if value.source.is_some_and(|s| s == "user") || value.uploader_id.is_some() {
 				Some(format!("{BASE_URL}/chapter/{}?source=user", value.id))
 			} else {


### PR DESCRIPTION
The group name has been left out by accident. This should make the chapter listing more accurate.