### PR TITLE
Fix for multi.mangadex Cloudflare Problem

### DIFF
--- a/sources/multi.mangadex/src/home.rs
+++ b/sources/multi.mangadex/src/home.rs
@@ -30,7 +30,7 @@ impl Home for MangaDex {
 			CUSTOM_LISTS
 				.iter()
 				.map(|list| format!("{API_URL}/list/{list}"))
-				.map(|url| Request::get(url).expect("invalid url format")),
+				.map(|url| crate::dex_get(url).expect("invalid url format")),
 		);
 		let custom_lists = &mut custom_list_requests
 			.iter_mut()
@@ -74,7 +74,7 @@ impl Home for MangaDex {
 
 		let owner_user_id = "d2ae45e0-b5e2-4e7f-a688-17925c2d7d6b";
 		let mut seasonal_res =
-			Request::get(format!("{API_URL}/user/{owner_user_id}/list"))?.send()?;
+			crate::dex_get(format!("{API_URL}/user/{owner_user_id}/list"))?.send()?;
 		if let Ok(response) = seasonal_res.get_json::<DexResponse<Vec<DexCustomList>>>() {
 			let current_seasonal_lists = response
 				.data
@@ -143,7 +143,7 @@ impl Home for MangaDex {
 
 		let responses: [core::result::Result<Response, RequestError>; 3] = Request::send_all([
 			// popular
-			Request::get(format!(
+			crate::dex_get(format!(
 				"{API_URL}/manga\
 					?includes[]=cover_art\
 					&includes[]=artist\
@@ -158,7 +158,7 @@ impl Home for MangaDex {
 					.format("%Y-%m-%dT%H:%M:%S")
 			))?,
 			// recently added
-			Request::get(format!(
+			crate::dex_get(format!(
 				"{API_URL}/manga\
 					?limit=15\
 					&order[createdAt]=desc\
@@ -166,7 +166,7 @@ impl Home for MangaDex {
 					{content_ratings}"
 			))?,
 			// latest
-			Request::get(format!(
+			crate::dex_get(format!(
 				"{API_URL}/chapter\
 					?includes[]=scanlation_group\
 					&limit=15\
@@ -260,7 +260,7 @@ impl Home for MangaDex {
 					{content_ratings}\
 					{manga_ids}"
 			);
-			let latest_manga = Request::get(latest_manga_url)?
+			let latest_manga = crate::dex_get(latest_manga_url)?
 				.send()?
 				.get_json::<DexResponse<Vec<DexManga>>>()?
 				.data
@@ -298,7 +298,7 @@ impl Home for MangaDex {
 		// custom lists components
 		{
 			let custom_list_responses = Request::send_all(custom_lists.iter().map(|list| {
-				Request::get(format!(
+				crate::dex_get(format!(
 					"{API_URL}/manga\
 						?limit=100\
 						&includes[]=cover_art\

--- a/sources/multi.mangadex/src/lib.rs
+++ b/sources/multi.mangadex/src/lib.rs
@@ -7,7 +7,7 @@ use aidoku::{
 	helpers::uri::QueryParameters,
 	imports::{
 		error::AidokuError,
-		net::{Request, TimeUnit, set_rate_limit},
+		net::{Request, RequestError, TimeUnit, set_rate_limit},
 		std::send_partial_result,
 	},
 	prelude::*,
@@ -37,6 +37,15 @@ const CUSTOM_LISTS: &[&str] = &[
 	"805ba886-dd99-4aa4-b460-4bd7c7b71352", // Staff Picks
 	"5c5e6e39-0b4b-413e-be59-27b1ba03d1b9", // Featured by Supporters
 ];
+
+// send a GET request to the MangaDex API, identifying ourselves so that
+// Cloudflare doesn't lump us in with anonymous/abusive traffic and return
+// an empty (non-JSON) response
+pub(crate) fn dex_get<T: AsRef<str>>(url: T) -> core::result::Result<Request, RequestError> {
+	Ok(Request::get(url)?
+		.header("User-Agent", "Aidoku")
+		.header("Referer", REFERER))
+}
 
 struct MangaDex;
 
@@ -171,7 +180,7 @@ impl Source for MangaDex {
 				&{qs}",
 		);
 
-		let (entries, has_next_page) = Request::get(url)?
+		let (entries, has_next_page) = dex_get(url)?
 			.send()?
 			.get_json::<DexResponse<Vec<DexManga>>>()
 			.map(|response| {
@@ -199,7 +208,7 @@ impl Source for MangaDex {
 	) -> Result<Manga> {
 		if needs_details {
 			manga.copy_from(
-				Request::get(format!(
+				dex_get(format!(
 					"{API_URL}/manga/{}\
 						?includes[]=cover_art\
 						&includes[]=author\
@@ -239,7 +248,7 @@ impl Source for MangaDex {
 				if show_unavailable_chapters { "1" } else { "0" }
 			);
 
-			let (mut chapters, total) = Request::get(&url)?
+			let (mut chapters, total) = dex_get(&url)?
 				.send()?
 				.get_json::<DexResponse<Vec<DexChapter>>>()
 				.map(|response| {
@@ -259,7 +268,7 @@ impl Source for MangaDex {
 				let mut offset = 500;
 				while offset < total {
 					let url = format!("{url}&offset={offset}");
-					if let Ok(response) = Request::get(&url)?
+					if let Ok(response) = dex_get(&url)?
 						.send()?
 						.get_json::<DexResponse<Vec<DexChapter>>>()
 					{
@@ -289,7 +298,7 @@ impl Source for MangaDex {
 			if force_port { "?forcePort443=true" } else { "" }
 		);
 
-		Request::get(&url)?
+		dex_get(&url)?
 			.send()?
 			.get_json::<DexAtHomeResponse>()
 			.and_then(|response| {
@@ -356,7 +365,7 @@ impl MangaDex {
 	fn get_author_ids(&self, name: &str) -> Result<Vec<String>> {
 		let url = format!("{API_URL}/author?name={name}",);
 
-		let ids = Request::get(url)?
+		let ids = dex_get(url)?
 			.send()?
 			.get_json::<DexResponse<Vec<DexData>>>()?
 			.data
@@ -371,7 +380,7 @@ impl MangaDex {
 	fn get_mangadex_list(&self, id: &str) -> Result<MangaPageResult> {
 		let content_ratings = settings::get_content_ratings()?;
 
-		let mut list_res = Request::get(format!("{API_URL}/list/{id}"))?.send()?;
+		let mut list_res = dex_get(format!("{API_URL}/list/{id}"))?.send()?;
 
 		let manga_ids = list_res
 			.get_json::<DexResponse<DexCustomList>>()?
@@ -388,7 +397,7 @@ impl MangaDex {
 			.collect::<Vec<&str>>();
 
 		// assume the list is 32 items or less (mangadex site uses this value)
-		let entries = Request::get(format!(
+		let entries = dex_get(format!(
 			"{API_URL}/manga\
 					?limit=100\
 					&includes[]=cover_art\
@@ -419,7 +428,7 @@ impl MangaDex {
 
 		let offset = (page - 1) * PAGE_SIZE;
 
-		let mut chapters_res = Request::get(format!(
+		let mut chapters_res = dex_get(format!(
 			"{API_URL}/chapter\
 				?includes[]=scanlation_group\
 				&limit={PAGE_SIZE}\
@@ -453,7 +462,7 @@ impl MangaDex {
 				{content_ratings}\
 				{ids_params}"
 		);
-		let entries = Request::get(url)?
+		let entries = dex_get(url)?
 			.send()?
 			.get_json::<DexResponse<Vec<DexManga>>>()?
 			.data
@@ -469,7 +478,7 @@ impl MangaDex {
 
 	// get the logged in user's library
 	fn get_library(&self, page: i32) -> Result<MangaPageResult> {
-		let status_ids = Request::get(format!("{API_URL}/manga/status"))?
+		let status_ids = dex_get(format!("{API_URL}/manga/status"))?
 			.authed_send()?
 			.get_json::<DexStatusResponse>()?
 			.statuses
@@ -493,7 +502,7 @@ impl MangaDex {
 				{status_ids}",
 		);
 
-		let (entries, has_next_page) = Request::get(manga_url)?
+		let (entries, has_next_page) = dex_get(manga_url)?
 			.authed_send()?
 			.get_json::<DexResponse<Vec<DexManga>>>()
 			.map(|response| {
@@ -543,7 +552,7 @@ impl AlternateCoverProvider for MangaDex {
 				""
 			}
 		);
-		let (mut items, total) = Request::get(&url)?
+		let (mut items, total) = dex_get(&url)?
 			.send()?
 			.get_json::<DexResponse<Vec<DexCoverArt>>>()
 			.map(|response| (response.data, response.total))?;
@@ -552,7 +561,7 @@ impl AlternateCoverProvider for MangaDex {
 			let mut offset = 100;
 			while offset < total {
 				let url = format!("{url}&offset={offset}");
-				if let Ok(response) = Request::get(url)?
+				if let Ok(response) = dex_get(url)?
 					.send()?
 					.get_json::<DexResponse<Vec<DexCoverArt>>>()
 				{
@@ -621,7 +630,7 @@ impl DeepLinkHandler for MangaDex {
 			let chapter_key = &key[..end];
 
 			let url = format!("{API_URL}/chapter/{chapter_key}");
-			let mut res = Request::get(&url)?.send()?;
+			let mut res = dex_get(&url)?.send()?;
 
 			let manga_key = res
 				.get_json::<DexResponse<DexChapter>>()?


### PR DESCRIPTION
Hello! 
I worked through this with a bit of Claude help since I wanna read manga asap but I read through the code, tested and verified live on my own device against the real MangaDex API - just putting it here in case this quick fix is good enough (pls don't get mad if its bad).

Summary
- Send User-Agent/Referer headers on all MangaDex API requests when previously only image requests had these so it had problems (identifying headers matches what image requests already do and looks like it avoids being treated as bad traffic).

Problem
- The MangaDex API was sometime giving empty responses, causing "Failed to parse popular/recent manga" errors and search failures on iOS. A few people including me had this problem.

Testing
- Built and deployed via a personal fork's GitHub Pages source list, installed on iOS device on 0.8.2
- Confirmed Home tab (Popular New Titles, Recently Added, Latest Updates) and search now load correctly! :D
- cargo fmt --check and cargo clippy all clean and well