### PR TITLE
fix(zh.happymh): update page decoding

### DIFF
--- a/sources/zh.happymh/Cargo.lock
+++ b/sources/zh.happymh/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aidoku"
 version = "0.3.0"
 source = "git+https://github.com/Aidoku/aidoku-rs#b0818704a5487778999bcd11239fa4c7a44da6ab"
@@ -50,10 +56,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
@@ -75,10 +102,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "embedded-io"
@@ -114,15 +170,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "happymh"
 version = "0.1.0"
 dependencies = [
  "aidoku",
  "aidoku-test",
+ "base64",
  "chrono",
+ "miniz_oxide",
  "regex",
  "serde",
  "serde_json",
+ "sha2",
 ]
 
 [[package]]
@@ -168,6 +237,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
 name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +262,15 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
 
 [[package]]
 name = "num-traits"
@@ -331,6 +415,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,7 +481,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"

--- a/sources/zh.happymh/Cargo.toml
+++ b/sources/zh.happymh/Cargo.toml
@@ -6,9 +6,12 @@ edition = "2024"
 [dependencies]
 aidoku = { git = "https://github.com/Aidoku/aidoku-rs", features = ["helpers", "json"] }
 chrono = { version = "0.4.31", default-features = false, features = ["serde"] }
+base64 = { version = "0.22.1", default-features = false, features = ["alloc"] }
+miniz_oxide = { version = "0.8.9", default-features = false, features = ["with-alloc"] }
 regex = { version = "1.11.1", default-features = false, features = ["unicode"] }
 serde = { version = "1.0.219", default-features = false }
 serde_json = { version = "1.0.140", default-features = false }
+sha2 = { version = "0.10.9", default-features = false }
 
 [dev-dependencies]
 aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", features = ["test"] }

--- a/sources/zh.happymh/res/source.json
+++ b/sources/zh.happymh/res/source.json
@@ -2,7 +2,7 @@
 	"info": {
 		"id": "zh.happymh",
 		"name": "Happymh",
-		"version": 5,
+		"version": 6,
 		"url": "https://m.happymh.com",
 		"contentRating": 1,
 		"languages": ["zh"]

--- a/sources/zh.happymh/src/json/page_list.rs
+++ b/sources/zh.happymh/src/json/page_list.rs
@@ -179,7 +179,7 @@ fn sha256(data: &[u8]) -> [u8; 32] {
 }
 
 fn decode_hex(input: &str) -> Result<Vec<u8>> {
-	if input.len() % 2 != 0 {
+	if !input.len().is_multiple_of(2) {
 		bail!("Invalid hex string");
 	}
 	let mut out = Vec::with_capacity(input.len() / 2);

--- a/sources/zh.happymh/src/json/page_list.rs
+++ b/sources/zh.happymh/src/json/page_list.rs
@@ -1,19 +1,22 @@
 use crate::BASE_URL;
 use aidoku::{
 	Page, Result,
-	alloc::{String, Vec, string::ToString as _},
+	alloc::{String, Vec, string::ToString as _, vec},
 	error,
 	imports::{net::Request, std::current_date},
 	prelude::*,
 };
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use sha2::{Digest as _, Sha256};
 
 pub struct PageList;
 
 impl PageList {
 	pub fn get_pages(manga_id: String, chapter_id: String) -> Result<Vec<Page>> {
 		let request_id = (current_date() * 1000).to_string();
+		let ga_timestamp = generate_ga_timestamp();
 		let url = format!(
-			"{}/v2.0/apis/manga/reading?code={}&cid={}&v=v4.203411&_t={}",
+			"{}/v2.0/apis/manga/reading?code={}&cid={}&v=v4.300101&_t={}",
 			BASE_URL, manga_id, chapter_id, request_id
 		);
 		let json: serde_json::Value = Request::get(url.clone())?
@@ -25,6 +28,14 @@ impl PageList {
 			.header("X-Requested-With", "XMLHttpRequest")
 			.header("X-Requested-Id", &request_id)
 			.header("Accept", "application/json")
+			.header(
+				"Cookie",
+				&format!(
+					"_ga_HVJMXGJXFJ=GS2.1.s{}$o9$g1$t{}$j43$l0$h0",
+					ga_timestamp,
+					ga_timestamp + 99999
+				),
+			)
 			.send()?
 			.get_json()?;
 		let data = json
@@ -34,23 +45,29 @@ impl PageList {
 			.get("data")
 			.and_then(|v| v.as_object())
 			.ok_or_else(|| error!("Expected data object"))?;
-		// `scans` can be either an array or a JSON string
-		let list: Vec<serde_json::Value> = match data.get("scans") {
-			Some(v) => {
-				if let Some(arr) = v.as_array() {
-					arr.clone()
-				} else if let Some(s) = v.as_str() {
-					let parsed: serde_json::Value = serde_json::from_str(s)
-						.map_err(|_| error!("Failed to parse scans JSON string"))?;
-					parsed
-						.as_array()
-						.ok_or_else(|| error!("Expected scans array after parsing"))?
-						.clone()
-				} else {
-					bail!("Expected scans array or JSON string");
-				}
-			}
-			None => bail!("Expected scans array"),
+		let is_encode = data
+			.get("isEncode")
+			.and_then(|v| v.as_bool())
+			.unwrap_or(false);
+		let scans = data
+			.get("scans")
+			.ok_or_else(|| error!("Expected scans field"))?;
+		let list: Vec<serde_json::Value> = if let Some(arr) = scans.as_array() {
+			arr.clone()
+		} else if let Some(s) = scans.as_str() {
+			let scans = if is_encode {
+				decode_scans(s)?
+			} else {
+				s.to_string()
+			};
+			let parsed: serde_json::Value = serde_json::from_str(&scans)
+				.map_err(|_| error!("Failed to parse scans JSON string"))?;
+			parsed
+				.as_array()
+				.ok_or_else(|| error!("Expected scans array after parsing"))?
+				.clone()
+		} else {
+			bail!("Expected scans array or JSON string");
 		};
 		let mut pages: Vec<Page> = Vec::new();
 
@@ -72,11 +89,7 @@ impl PageList {
 				.unwrap_or_default()
 				.to_string();
 
-			let width = item.get("width").and_then(|v| v.as_i64()).unwrap_or(0);
-			let height = item.get("height").and_then(|v| v.as_i64()).unwrap_or(0);
-			if (width > 16383 || height > 16383)
-				&& let Some(stripped) = url.split("?q=").next()
-			{
+			if let Some(stripped) = url.split("?q=").next() {
 				url = stripped.to_string();
 			}
 
@@ -87,5 +100,102 @@ impl PageList {
 		}
 
 		Ok(pages)
+	}
+}
+
+fn generate_ga_timestamp() -> i64 {
+	const TABLE: [i64; 10] = [335, 984, 248, 485, 524, 559, 486, 165, 114, 103];
+	let seconds = current_date();
+	let digits = seconds.to_string();
+	let bytes = digits.as_bytes();
+	let len = bytes.len();
+	let sum = TABLE[(bytes[len - 3] - b'0') as usize]
+		+ TABLE[(bytes[len - 2] - b'0') as usize]
+		+ TABLE[(bytes[len - 1] - b'0') as usize];
+	let checksum = sum.to_string();
+	let checksum = &checksum[..3];
+	format!("{}{}", digits, checksum)
+		.parse()
+		.unwrap_or(seconds * 1000)
+}
+
+fn decode_scans(encrypted_scans: &str) -> Result<String> {
+	const SECRET: &[u8] = b"DEV_SCAN_SECRET_2026_change_me";
+	const DOMAIN: &[u8] = b"happymh.com";
+
+	let buf = encrypted_scans.as_bytes();
+	if buf.len() < 8 {
+		bail!("Invalid encoded scans");
+	}
+
+	let digest = sha256(&[SECRET, &buf[..8], DOMAIN].concat());
+	let off1 = (digest[0] as usize) % 24 + 8;
+	let off2 = (digest[1] as usize) % 24 + 8;
+	let off3 = (digest[2] as usize) % 24 + 8;
+
+	let key_start = off1 + 8;
+	let key_end = key_start + 64;
+	let nonce_start = key_end + off2;
+	let nonce_end = nonce_start + 32;
+	let cipher_start = nonce_end + off3;
+	if encrypted_scans.len() < cipher_start {
+		bail!("Encoded scans too short for computed offsets");
+	}
+
+	let key = decode_hex(&encrypted_scans[key_start..key_end])?;
+	let nonce = decode_hex(&encrypted_scans[nonce_start..nonce_end])?;
+	let ciphertext = STANDARD
+		.decode(&encrypted_scans[cipher_start..])
+		.map_err(|_| error!("Failed to decode scans base64"))?;
+
+	let mut state = [0_u8; 52];
+	state[..32].copy_from_slice(&key);
+	state[32..48].copy_from_slice(&nonce);
+
+	let mut plain = vec![0_u8; ciphertext.len()];
+	for i in (0..ciphertext.len()).step_by(32) {
+		let block_idx = (i / 32) as u32;
+		state[48..52].copy_from_slice(&block_idx.to_be_bytes());
+		let keystream = sha256(&state);
+		let block_size = core::cmp::min(32, ciphertext.len() - i);
+		for j in 0..block_size {
+			plain[i + j] = ciphertext[i + j] ^ keystream[j];
+		}
+	}
+
+	if !plain.starts_with(b"SC01") {
+		bail!("Decoding scans failed");
+	}
+
+	let decompressed = miniz_oxide::inflate::decompress_to_vec(&plain[4..])
+		.map_err(|_| error!("Failed to decompress scans"))?;
+	String::from_utf8(decompressed).map_err(|_| error!("Failed to decode scans utf8"))
+}
+
+fn sha256(data: &[u8]) -> [u8; 32] {
+	let mut hasher = Sha256::new();
+	hasher.update(data);
+	hasher.finalize().into()
+}
+
+fn decode_hex(input: &str) -> Result<Vec<u8>> {
+	if input.len() % 2 != 0 {
+		bail!("Invalid hex string");
+	}
+	let mut out = Vec::with_capacity(input.len() / 2);
+	for chunk in input.as_bytes().chunks(2) {
+		let high = hex_value(chunk[0])?;
+		let low = hex_value(chunk[1])?;
+		out.push((high << 4) | low);
+	}
+	Ok(out)
+}
+
+fn hex_value(byte: u8) -> Result<u8> {
+	match byte {
+		b'0'..=b'9' => Ok(byte - b'0'),
+		b'a'..=b'f' => Ok(byte - b'a' + 10),
+		b'A'..=b'F' => Ok(byte - b'A' + 10),
+		_ => bail!("Invalid hex character"),
 	}
 }


### PR DESCRIPTION
## Summary
- update the Happymh reading API request version and required analytics cookie
- decode the new encoded `data.scans` string format before parsing pages
- use raw deflate decompression for decoded scan payloads and strip image quality query parameters

## Verification
- Verified in Aidoku with `shaosong/6596192` and `shaosong/6632830`; both decoded scans successfully and returned 17 pages.
- Checked that `source.json` remains valid JSON with tab indentation and bumps Happymh from v5 to v6.
- `git diff --check` passes.

I could not run `cargo fmt`, `cargo clippy`, or `cargo check` locally after removing the temporary Rust toolchain from my machine; the PR workflow should run the source build/verification.