### PR TITLE
feat(multi.mangadotnet): Add Volume feature

### DIFF
--- a/sources/multi.mangadotnet/res/settings.json
+++ b/sources/multi.mangadotnet/res/settings.json
@@ -21,6 +21,15 @@
 				"refreshes": [
 					"content"
 				]
+			},
+			{
+				"type": "switch",
+				"key": "showVolumes",
+				"title": "Show Standalone Volumes",
+				"default": false,
+				"refreshes": [
+					"content"
+				]
 			}
 		],
 		"footer": "Official chapters are preferred, followed by the most recent. Warning: It can be slow on large lists."

--- a/sources/multi.mangadotnet/res/source.json
+++ b/sources/multi.mangadotnet/res/source.json
@@ -2,7 +2,7 @@
 	"info": {
 		"id": "multi.mangadotnet",
 		"name": "Mangadotnet",
-		"version": 2,
+		"version": 3,
 		"url": "https://mangadot.net",
 		"contentRating": 1,
 		"languages": [

--- a/sources/multi.mangadotnet/src/helpers.rs
+++ b/sources/multi.mangadotnet/src/helpers.rs
@@ -72,17 +72,27 @@ fn is_official_like(chapter: &MangaChapter) -> bool {
 		10110, // LINE Webtoon
 		16168, // Tapas
 		3521,  // Comikey
+		18180, // One Peace Books
+		3891,  // J-Novel Club
+		18036, // Manga UP!
+		18234, // Square Enix Manga
+		18052, // Seven Seas Entertainment
 	];
 
 	// There are probably others but tbh, they have not standardized this properly so this is
 	// only a small chunk that I know of. Wait for the site to mature better before optimizing
 	// this function. (And this only works for maybe 1% of the manga available)
-	let official_scanlator_names = ["Official", "Official?", "MangaPlus", "Comikey"];
+	let official_scanlator_names = ["Official", "Official?", "MangaPlus", "Comikey", "K-Manga"];
 
 	let group_id = chapter
 		.group_id
 		.as_ref()
 		.is_some_and(|id| official_group_ids.contains(id));
+
+	let group_ids = chapter
+		.groups
+		.as_ref()
+		.is_some_and(|groups| groups.iter().any(|g| official_group_ids.contains(&g.id)));
 
 	let scanlator_name = chapter.scanlator_name.as_ref().is_some_and(|name| {
 		official_scanlator_names
@@ -90,7 +100,7 @@ fn is_official_like(chapter: &MangaChapter) -> bool {
 			.any(|s| s.to_lowercase() == name.to_lowercase())
 	});
 
-	group_id || scanlator_name
+	group_id || group_ids || scanlator_name
 }
 
 fn is_better(new: &MangaChapter, current: &MangaChapter) -> bool {
@@ -110,7 +120,10 @@ fn is_better(new: &MangaChapter, current: &MangaChapter) -> bool {
 }
 
 pub fn dedup_insert(map: &mut HashMap<String, MangaChapter>, chapter: MangaChapter) {
-	let key = chapter.chapter_number.to_string();
+	let key: String = chapter
+		.chapter_number
+		.map(|n| n.to_string())
+		.unwrap_or("0".into());
 	match map.get(&key) {
 		None => {
 			map.insert(key, chapter);

--- a/sources/multi.mangadotnet/src/lib.rs
+++ b/sources/multi.mangadotnet/src/lib.rs
@@ -242,10 +242,38 @@ impl Source for Mangadotnet {
 				chapter_list.into_iter().map(Into::into).collect()
 			};
 
+			if show_standalone_volume() {
+				let volumes_json: Vec<MangaVolume> =
+					self.get_json_data(&format!("{BASE_URL}/api/manga/{}/volumes", manga.key))?;
+
+				let mut volumes: Vec<Chapter> = volumes_json.into_iter().map(Into::into).collect();
+				chapters.append(&mut volumes);
+			}
+
 			chapters.sort_by(|a, b| {
-				b.chapter_number
-					.partial_cmp(&a.chapter_number)
+				// 1) volume descending (None goes last)
+				match b
+					.volume_number
+					.partial_cmp(&a.volume_number)
 					.unwrap_or(Ordering::Equal)
+				{
+					Ordering::Equal => {
+						match (&a.chapter_number, &b.chapter_number) {
+							// 2) both have chapter numbers -> chapter descending
+							(Some(a_ch), Some(b_ch)) => {
+								b_ch.partial_cmp(a_ch).unwrap_or(Ordering::Equal)
+							}
+
+							// 3) chapter entries come before volume-only entries
+							(Some(_), None) => Ordering::Less,
+							(None, Some(_)) => Ordering::Greater,
+
+							// 4) both volume-only
+							(None, None) => Ordering::Equal,
+						}
+					}
+					ord => ord,
+				}
 			});
 
 			manga.chapters = Some(chapters);

--- a/sources/multi.mangadotnet/src/models.rs
+++ b/sources/multi.mangadotnet/src/models.rs
@@ -196,7 +196,8 @@ impl From<MangaItem> for Link {
 pub struct MangaChapter {
 	pub id: i32,
 	#[serde(deserialize_with = "f32_from_any")]
-	pub chapter_number: f32,
+	pub chapter_number: Option<f32>,
+	#[serde(deserialize_with = "f32_from_any", default = "default_option_f32")]
 	pub volume_number: Option<f32>,
 	pub chapter_title: Option<String>,
 	pub language: Option<String>,
@@ -207,9 +208,39 @@ pub struct MangaChapter {
 	pub date_added: String,
 	pub source: Option<String>,
 	pub scanlator_name: Option<String>,
+	pub groups: Option<Vec<MangaGroup>>,
+}
+
+#[derive(Deserialize)]
+pub struct MangaGroup {
+	pub id: i32,
+	pub name: String,
+}
+
+#[derive(Deserialize)]
+pub struct MangaVolume {
+	pub id: i32,
+	pub volume_number: f32,
+	pub cover_url: Option<String>,
+	pub group_name: Option<String>,
+	pub uploader_username: Option<String>,
+	pub date_added: String,
+	pub scanlator_name: Option<String>,
+	pub groups: Vec<MangaGroup>,
 }
 
 impl MangaChapter {
+	pub fn created_at(&self) -> Option<i64> {
+		// Old upload is using old format and new uploads are using new format.
+		// This should probably handle both.
+		parse_date(&self.date_added, "yyyy-MM-dd HH:mm:ssZZZ").or(parse_date(
+			&self.date_added,
+			"yyyy-MM-dd HH:mm:ss.SSSSSSZZZ",
+		))
+	}
+}
+
+impl MangaVolume {
 	pub fn created_at(&self) -> Option<i64> {
 		// Old upload is using old format and new uploads are using new format.
 		// This should probably handle both.
@@ -228,19 +259,50 @@ impl From<MangaChapter> for Chapter {
 			title: value
 				.chapter_title
 				.filter(|title| !title.to_lowercase().starts_with("chapter")),
-			chapter_number: Some(value.chapter_number),
+			chapter_number: value.chapter_number,
 			volume_number: value.volume_number,
 			date_uploaded: date,
 			scanlators: value
-				.group_name
-				.or(value.scanlator_name)
-				.map(|name| vec![name]),
+				.groups
+				.map(|g| g.into_iter().map(|group| group.name).collect())
+				.or(value.scanlator_name.map(|name| vec![name])),
 			url: if value.source.is_some_and(|s| s == "user") || value.uploader_id.is_some() {
 				Some(format!("{BASE_URL}/chapter/{}?source=user", value.id))
 			} else {
 				Some(format!("{BASE_URL}/chapter/{}", value.id))
 			},
 			language: value.language,
+			..Default::default()
+		}
+	}
+}
+
+impl From<MangaVolume> for Chapter {
+	fn from(value: MangaVolume) -> Self {
+		let date = value.created_at();
+		Self {
+			key: value.id.to_string(),
+			title: None,
+			chapter_number: None,
+			volume_number: Some(value.volume_number),
+			date_uploaded: date,
+			scanlators: if !value.groups.is_empty() {
+				Some(value.groups.into_iter().map(|group| group.name).collect())
+			} else {
+				value.scanlator_name.map(|name| vec![name])
+			},
+			url: if value.uploader_username.is_some() {
+				Some(format!(
+					"{BASE_URL}/chapter/{}?source=user&mode=volume",
+					value.id
+				))
+			} else {
+				Some(format!("{BASE_URL}/chapter/{}?mode=volume", value.id))
+			},
+			language: Some("en".into()),
+			thumbnail: value
+				.cover_url
+				.map(|cover_url| format!("{BASE_URL}/{cover_url}")),
 			..Default::default()
 		}
 	}
@@ -306,11 +368,11 @@ fn bool_from_any<'de, D: Deserializer<'de>>(deserializer: D) -> Result<bool, D::
 	deserializer.deserialize_any(BoolVisitor)
 }
 
-fn f32_from_any<'de, D: Deserializer<'de>>(deserializer: D) -> Result<f32, D::Error> {
+fn f32_from_any<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Option<f32>, D::Error> {
 	struct F32Visitor;
 
 	impl<'de> de::Visitor<'de> for F32Visitor {
-		type Value = f32;
+		type Value = Option<f32>;
 
 		fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
 			formatter.write_str("a number that can be converted to f32")
@@ -320,49 +382,56 @@ fn f32_from_any<'de, D: Deserializer<'de>>(deserializer: D) -> Result<f32, D::Er
 		where
 			E: Error,
 		{
-			Ok(v as f32)
+			Ok(Some(v as f32))
 		}
 
 		fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
 		where
 			E: Error,
 		{
-			Ok(v as f32)
+			Ok(Some(v as f32))
 		}
 
 		fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
 		where
 			E: Error,
 		{
-			Ok(v as f32)
+			Ok(Some(v as f32))
 		}
 
 		fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 		where
 			E: Error,
 		{
-			Ok(v as f32)
+			Ok(Some(v as f32))
 		}
 
 		fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
 		where
 			E: Error,
 		{
-			Ok(v)
+			Ok(Some(v))
 		}
 
 		fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
 		where
 			E: Error,
 		{
-			Ok(v as f32)
+			Ok(Some(v as f32))
 		}
 
 		fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
 		where
 			E: Error,
 		{
-			v.parse::<f32>().map_err(Error::custom)
+			v.parse::<f32>().map(Some).map_err(Error::custom)
+		}
+
+		fn visit_unit<E>(self) -> Result<Self::Value, E>
+		where
+			E: Error,
+		{
+			Ok(None)
 		}
 	}
 
@@ -371,4 +440,8 @@ fn f32_from_any<'de, D: Deserializer<'de>>(deserializer: D) -> Result<f32, D::Er
 
 fn default_bool() -> bool {
 	false
+}
+
+fn default_option_f32() -> Option<f32> {
+	None
 }

--- a/sources/multi.mangadotnet/src/settings.rs
+++ b/sources/multi.mangadotnet/src/settings.rs
@@ -8,8 +8,9 @@ use aidoku::{
 
 const HIDE_NSFW_KEY: &str = "hideNSFW";
 const DEDUPED_CHAPTER_KEY: &str = "dedupedChapter";
+const SHOW_STANALONE_VOLUME_KEY: &str = "showVolumes";
 
-const USE_VIEW_WEB_WORKAROUND_KEY: &str = "useWebViewFetch";
+const USE_WEB_VIEW_WORKAROUND_KEY: &str = "useWebViewFetch";
 
 const DEFAULT_CONTENT_TYPES_KEY: &str = "contentTypes";
 
@@ -43,8 +44,12 @@ pub fn deduped_chapter() -> bool {
 	defaults_get::<bool>(DEDUPED_CHAPTER_KEY).unwrap_or(false)
 }
 
+pub fn show_standalone_volume() -> bool {
+	defaults_get::<bool>(SHOW_STANALONE_VOLUME_KEY).unwrap_or(false)
+}
+
 pub fn use_view_web_worker() -> bool {
-	defaults_get::<bool>(USE_VIEW_WEB_WORKAROUND_KEY).unwrap_or(false)
+	defaults_get::<bool>(USE_WEB_VIEW_WORKAROUND_KEY).unwrap_or(false)
 }
 
 pub fn get_default_content_types() -> Option<String> {


### PR DESCRIPTION
This update adds the ability to see standalone volumes alongside with normal chapter. (Opt-in in settings)

I have updated a few more official group ids and actually fixed the unintended naming mistakes.

CF related bugs fixes is available in the nightly version of Aidoku and seems to be working well. Error message might reflect some changes once it is made available in public.