### PR TITLE
fix(en.freewebnovel): load full paginated chapter list

### DIFF
--- a/sources/en.freewebnovel/res/source.json
+++ b/sources/en.freewebnovel/res/source.json
@@ -2,7 +2,7 @@
 	"info": {
 		"id": "en.freewebnovel",
 		"name": "FreeWebNovel",
-		"version": 2,
+		"version": 3,
 		"url": "https://freewebnovel.com",
 		"contentRating": 1,
 		"languages": [

--- a/sources/en.freewebnovel/src/helpers.rs
+++ b/sources/en.freewebnovel/src/helpers.rs
@@ -5,16 +5,44 @@ use aidoku::{
 	imports::{
 		html::{Document, Element, Kind},
 		net::Request,
+		std::sleep,
 	},
 	prelude::*,
 };
 
+/// Fetches a URL as an HTML document, transparently retrying on HTTP 429.
+///
+/// The site rate-limits bursts (~15 requests) with a `429 Too Many Requests`
+/// and a `Retry-After` header (typically 10s). Fetching a long novel's chapter
+/// list needs many sequential page requests, so we honor `Retry-After` and
+/// retry rather than silently dropping chapters.
 pub fn request_html(url: &str) -> Result<Document> {
-	Ok(Request::get(url)?.html()?)
+	const MAX_RETRIES: u32 = 3;
+	const DEFAULT_RETRY_AFTER: i32 = 10;
+	let mut attempt = 0;
+	loop {
+		let response = Request::get(url)?.send()?;
+		if response.status_code() == 429 && attempt < MAX_RETRIES {
+			let wait = response
+				.get_header("retry-after")
+				.and_then(|v| v.parse::<i32>().ok())
+				.unwrap_or(DEFAULT_RETRY_AFTER)
+				.clamp(1, 30);
+			sleep(wait);
+			attempt += 1;
+			continue;
+		}
+		return Ok(response.get_html()?);
+	}
 }
 
+/// Maximum chapters the site returns per page; larger `pageSize` values clamp
+/// to this. Requesting the max minimizes the number of chapter-list requests
+/// (keeping even long novels under the rate-limit threshold).
+const CHAPTERS_PER_PAGE: usize = 200;
+
 pub fn build_novel_url(slug: &str) -> String {
-	format!("{BASE_URL}/novel/{slug}")
+	format!("{BASE_URL}/novel/{slug}?pageSize={CHAPTERS_PER_PAGE}")
 }
 
 pub fn build_chapter_url(slug: &str, chapter_key: &str) -> String {
@@ -93,39 +121,72 @@ pub fn content_rating_from_tags(tags: &[String]) -> ContentRating {
 	}
 }
 
-/// Extract Chapters from Novel page.
+/// Total number of chapters, parsed from the index `<select>`.
+///
+/// The `<select id="indexselect">` lists chapter ranges in 40-chapter chunks
+/// (e.g. last option `"C.801 - C.809"`), regardless of the requested
+/// `pageSize`. The last option's trailing number is the total chapter count.
+/// Returns `None` for short novels that have no select (single page).
+pub fn total_chapter_count(html: &Document) -> Option<usize> {
+	let last = html.select("select#indexselect option")?.next_back()?;
+	let text = last.text()?;
+	text.split(|c: char| !c.is_ascii_digit())
+		.rfind(|s| !s.is_empty())
+		.and_then(|n| n.parse().ok())
+}
+
+/// Parse a single chapter `<li>` element into a [Chapter].
+fn chapter_from_item(item: &Element) -> Option<Chapter> {
+	let link = item.select_first("a[href]")?;
+	let url = link.attr("abs:href")?;
+	let (_, chapter_key) = parse_novel_and_chapter(&url)?;
+	let chapter_key = chapter_key?;
+	let mut title = link.text()?;
+	let chapter_number = parse_chapter_number(&title);
+	if let Some(chapter_number) = chapter_number {
+		title = match title.strip_prefix(&format!("Chapter {chapter_number}")) {
+			Some(rest) => rest
+				.trim()
+				.strip_prefix(':')
+				.or_else(|| rest.trim().strip_prefix('-'))
+				.map_or_else(|| rest.trim().to_string(), |t| t.trim().to_string()),
+			None => title,
+		};
+	};
+	Some(Chapter {
+		key: chapter_key,
+		title: { if !title.is_empty() { Some(title) } else { None } },
+		chapter_number,
+		url: Some(url),
+		..Default::default()
+	})
+}
+
+/// Extract Chapters from a single novel chapter-list page, in ascending order.
 pub fn extract_chapters(html: &Document) -> Vec<Chapter> {
 	let Some(items) = html.select("div.m-newest2 > ul.ul-list5 > li") else {
 		return Vec::new();
 	};
-	items
-		.rev()
-		.filter_map(|item| {
-			let link = item.select_first("a[href]")?;
-			let url = link.attr("abs:href")?;
-			let (_, chapter_key) = parse_novel_and_chapter(&url)?;
-			let chapter_key = chapter_key?;
-			let mut title = link.text()?;
-			let chapter_number = parse_chapter_number(&title);
-			if let Some(chapter_number) = chapter_number {
-				title = match title.strip_prefix(&format!("Chapter {chapter_number}")) {
-					Some(rest) => rest
-						.trim()
-						.strip_prefix(':')
-						.or_else(|| rest.trim().strip_prefix('-'))
-						.map_or_else(|| rest.trim().to_string(), |t| t.trim().to_string()),
-					None => title,
-				};
-			};
-			Some(Chapter {
-				key: chapter_key,
-				title: { if !title.is_empty() { Some(title) } else { None } },
-				chapter_number,
-				url: Some(url),
-				..Default::default()
-			})
-		})
-		.collect()
+	items.filter_map(|item| chapter_from_item(&item)).collect()
+}
+
+/// Fetch a novel's full chapter list, newest-first (as Aidoku expects).
+///
+/// `first_page` is the already-loaded novel page, which `build_novel_url` loads
+/// at `pageSize=200`, so it is reused for the first page; only the remaining
+/// pages are fetched. `request_html` transparently retries on the site's 429
+/// rate limit.
+pub fn fetch_all_chapters(first_page: &Document, slug: &str) -> Result<Vec<Chapter>> {
+	let mut chapters = extract_chapters(first_page);
+	let page_count =
+		total_chapter_count(first_page).map_or(1, |total| total.div_ceil(CHAPTERS_PER_PAGE));
+	for page in 2..=page_count {
+		let page_url = format!("{}&page={page}", build_novel_url(slug));
+		chapters.extend(extract_chapters(&request_html(&page_url)?));
+	}
+	// Pages list chapters oldest-first; Aidoku expects newest-first.
+	chapters.reverse();
+	Ok(chapters)
 }
 
 fn convert_element_to_markdown(element: &Element, output: &mut String) {

--- a/sources/en.freewebnovel/src/helpers.rs
+++ b/sources/en.freewebnovel/src/helpers.rs
@@ -5,35 +5,12 @@ use aidoku::{
 	imports::{
 		html::{Document, Element, Kind},
 		net::Request,
-		std::sleep,
 	},
 	prelude::*,
 };
 
-/// Fetches a URL as an HTML document, transparently retrying on HTTP 429.
-///
-/// The site rate-limits bursts (~15 requests) with a `429 Too Many Requests`
-/// and a `Retry-After` header (typically 10s). Fetching a long novel's chapter
-/// list needs many sequential page requests, so we honor `Retry-After` and
-/// retry rather than silently dropping chapters.
 pub fn request_html(url: &str) -> Result<Document> {
-	const MAX_RETRIES: u32 = 3;
-	const DEFAULT_RETRY_AFTER: i32 = 10;
-	let mut attempt = 0;
-	loop {
-		let response = Request::get(url)?.send()?;
-		if response.status_code() == 429 && attempt < MAX_RETRIES {
-			let wait = response
-				.get_header("retry-after")
-				.and_then(|v| v.parse::<i32>().ok())
-				.unwrap_or(DEFAULT_RETRY_AFTER)
-				.clamp(1, 30);
-			sleep(wait);
-			attempt += 1;
-			continue;
-		}
-		return Ok(response.get_html()?);
-	}
+	Ok(Request::get(url)?.html()?)
 }
 
 /// Maximum chapters the site returns per page; larger `pageSize` values clamp
@@ -155,38 +132,39 @@ fn chapter_from_item(item: &Element) -> Option<Chapter> {
 	};
 	Some(Chapter {
 		key: chapter_key,
-		title: { if !title.is_empty() { Some(title) } else { None } },
+		title: if !title.is_empty() { Some(title) } else { None },
 		chapter_number,
 		url: Some(url),
 		..Default::default()
 	})
 }
 
-/// Extract Chapters from a single novel chapter-list page, in ascending order.
-pub fn extract_chapters(html: &Document) -> Vec<Chapter> {
-	let Some(items) = html.select("div.m-newest2 > ul.ul-list5 > li") else {
-		return Vec::new();
-	};
-	items.filter_map(|item| chapter_from_item(&item)).collect()
+/// Iterate the chapters on a single novel chapter-list page, in ascending order.
+fn extract_chapters(html: &Document) -> impl DoubleEndedIterator<Item = Chapter> {
+	html.select("div.m-newest2 > ul.ul-list5 > li")
+		.into_iter()
+		.flatten()
+		.filter_map(|item| chapter_from_item(&item))
 }
 
 /// Fetch a novel's full chapter list, newest-first (as Aidoku expects).
 ///
 /// `first_page` is the already-loaded novel page, which `build_novel_url` loads
 /// at `pageSize=200`, so it is reused for the first page; only the remaining
-/// pages are fetched. `request_html` transparently retries on the site's 429
-/// rate limit.
+/// pages are fetched. The pages are kept alive in `rest` while their chapters
+/// are read, since the parsed elements reference them.
 pub fn fetch_all_chapters(first_page: &Document, slug: &str) -> Result<Vec<Chapter>> {
-	let mut chapters = extract_chapters(first_page);
 	let page_count =
 		total_chapter_count(first_page).map_or(1, |total| total.div_ceil(CHAPTERS_PER_PAGE));
-	for page in 2..=page_count {
-		let page_url = format!("{}&page={page}", build_novel_url(slug));
-		chapters.extend(extract_chapters(&request_html(&page_url)?));
-	}
-	// Pages list chapters oldest-first; Aidoku expects newest-first.
-	chapters.reverse();
-	Ok(chapters)
+	let rest = (2..=page_count)
+		.map(|page| request_html(&format!("{}&page={page}", build_novel_url(slug))))
+		.collect::<Result<Vec<Document>>>()?;
+	// Pages list chapters oldest-first; reverse the whole sequence for newest-first.
+	Ok(core::iter::once(first_page)
+		.chain(rest.iter())
+		.flat_map(extract_chapters)
+		.rev()
+		.collect())
 }
 
 fn convert_element_to_markdown(element: &Element, output: &mut String) {

--- a/sources/en.freewebnovel/src/lib.rs
+++ b/sources/en.freewebnovel/src/lib.rs
@@ -5,7 +5,10 @@ use aidoku::{
 	Source,
 	alloc::{String, Vec, vec},
 	helpers::uri::QueryParameters,
-	imports::std::send_partial_result,
+	imports::{
+		net::{TimeUnit, set_rate_limit},
+		std::send_partial_result,
+	},
 	prelude::*,
 };
 
@@ -26,6 +29,8 @@ struct FreeWebNovel;
 
 impl Source for FreeWebNovel {
 	fn new() -> Self {
+		// The site rate-limits bursts (~15 requests) with a 429
+		set_rate_limit(12, 10, TimeUnit::Seconds);
 		Self
 	}
 
@@ -203,12 +208,11 @@ mod tests {
 			.expect("get_manga_update failed");
 		assert!(manga.title.to_ascii_lowercase().contains("swordmaster"));
 		let chapters = manga.chapters.expect("no chapters returned");
-		// The series spans 800+ chapters across 20+ paginated requests, which
-		// trips the site's rate limit mid-fetch. Asserting a high count proves
-		// the 429 retry pulls every page rather than silently truncating.
+		// The series spans 800+ chapters across multiple pages; asserting a high
+		// count proves every page is fetched and concatenated, not just the first.
 		assert!(
 			chapters.len() > 800,
-			"expected full chapter list (rate-limit retry), got {}",
+			"expected full chapter list, got {}",
 			chapters.len()
 		);
 		// Chapters should be a contiguous run with no gaps from dropped pages.

--- a/sources/en.freewebnovel/src/lib.rs
+++ b/sources/en.freewebnovel/src/lib.rs
@@ -12,7 +12,7 @@ use aidoku::{
 mod helpers;
 
 use helpers::{
-	build_chapter_url, build_novel_url, build_sort_url, extract_chapter_text, extract_chapters,
+	build_chapter_url, build_novel_url, build_sort_url, extract_chapter_text, fetch_all_chapters,
 	fill_manga_details, has_next_page, parse_home_section, parse_hot_entries,
 	parse_novel_and_chapter, parse_search_results, request_html,
 };
@@ -65,8 +65,7 @@ impl Source for FreeWebNovel {
 		}
 
 		if needs_chapters {
-			let chapters = extract_chapters(&html);
-			manga.chapters = Some(chapters);
+			manga.chapters = Some(fetch_all_chapters(&html, &manga.key)?);
 		}
 
 		Ok(manga)
@@ -204,10 +203,32 @@ mod tests {
 			.expect("get_manga_update failed");
 		assert!(manga.title.to_ascii_lowercase().contains("swordmaster"));
 		let chapters = manga.chapters.expect("no chapters returned");
+		// The series spans 800+ chapters across 20+ paginated requests, which
+		// trips the site's rate limit mid-fetch. Asserting a high count proves
+		// the 429 retry pulls every page rather than silently truncating.
 		assert!(
-			chapters.len() > 50,
-			"expected lots of chapters, got {}",
+			chapters.len() > 800,
+			"expected full chapter list (rate-limit retry), got {}",
 			chapters.len()
+		);
+		// Chapters should be a contiguous run with no gaps from dropped pages.
+		let mut nums: Vec<i32> = chapters
+			.iter()
+			.filter_map(|c| c.key.strip_prefix("chapter-").and_then(|n| n.parse().ok()))
+			.collect();
+		nums.sort_unstable();
+		if let (Some(&lo), Some(&hi)) = (nums.first(), nums.last()) {
+			let missing = (lo..=hi).filter(|n| !nums.contains(n)).count();
+			assert_eq!(missing, 0, "expected no gaps in chapter numbers");
+		}
+		// Newest-first ordering: first entry should be the highest chapter.
+		assert_eq!(
+			chapters.first().and_then(|c| c.chapter_number),
+			chapters
+				.iter()
+				.filter_map(|c| c.chapter_number)
+				.fold(None, |max, n| Some(max.map_or(n, |m: f32| m.max(n)))),
+			"expected newest chapter first"
 		);
 	}
 


### PR DESCRIPTION
The site now paginates chapter lists, so only the first 40 chapters loaded. Fetch all pages via ?page=N&pageSize=200, with 429 rate-limit retry handling.