### PR TITLE
fix(en.freewebnovel): load all chapters via pagination

### DIFF
--- a/sources/en.freewebnovel/Cargo.lock
+++ b/sources/en.freewebnovel/Cargo.lock
@@ -14,6 +14,7 @@ dependencies = [
  "paste",
  "postcard",
  "serde",
+ "serde_json",
  "talc",
  "thiserror",
 ]
@@ -108,6 +109,7 @@ version = "0.1.0"
 dependencies = [
  "aidoku",
  "aidoku-test",
+ "serde",
 ]
 
 [[package]]
@@ -166,6 +168,12 @@ checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "num-traits"
@@ -266,6 +274,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,3 +346,9 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/sources/en.freewebnovel/Cargo.toml
+++ b/sources/en.freewebnovel/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", version = "0.3.0" }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", version = "0.3.0", features = ["json"] }
+serde = { version = "1.0", features = ["derive", "alloc"], default-features = false }
 
 [dev-dependencies]
 aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", features = ["test"] }

--- a/sources/en.freewebnovel/res/source.json
+++ b/sources/en.freewebnovel/res/source.json
@@ -2,7 +2,7 @@
 	"info": {
 		"id": "en.freewebnovel",
 		"name": "FreeWebNovel",
-		"version": 2,
+		"version": 3,
 		"url": "https://freewebnovel.com",
 		"contentRating": 1,
 		"languages": [

--- a/sources/en.freewebnovel/src/helpers.rs
+++ b/sources/en.freewebnovel/src/helpers.rs
@@ -3,11 +3,16 @@ use aidoku::{
 	Chapter, ContentRating, Manga, MangaStatus, Result,
 	alloc::{String, Vec, string::ToString},
 	imports::{
-		html::{Document, Element, Kind},
+		html::{Document, Element, Html, Kind},
 		net::Request,
 	},
 	prelude::*,
 };
+use serde::Deserialize;
+
+/// Maximum chapters the AJAX chapter-list endpoint returns per request.
+/// Larger values are clamped to this server-side.
+const CHAPTER_PAGE_SIZE: i32 = 200;
 
 pub fn request_html(url: &str) -> Result<Document> {
 	Ok(Request::get(url)?.html()?)
@@ -93,39 +98,86 @@ pub fn content_rating_from_tags(tags: &[String]) -> ContentRating {
 	}
 }
 
-/// Extract Chapters from Novel page.
-pub fn extract_chapters(html: &Document) -> Vec<Chapter> {
-	let Some(items) = html.select("div.m-newest2 > ul.ul-list5 > li") else {
-		return Vec::new();
+/// Response shape of the AJAX chapter-list endpoint
+/// (`/novel/{slug}?ajax=chapters&page=N&pageSize=N`).
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ChapterListResponse {
+	/// `<li>` chapter items for the requested page, as an HTML fragment.
+	html: String,
+	/// Total number of chapter pages for the current `pageSize`.
+	total_page: i32,
+}
+
+/// Fetch a single page of the chapter list through the AJAX endpoint.
+fn fetch_chapter_page(slug: &str, page: i32) -> Result<ChapterListResponse> {
+	let url =
+		format!("{BASE_URL}/novel/{slug}?ajax=chapters&page={page}&pageSize={CHAPTER_PAGE_SIZE}");
+	Request::get(&url)?
+		.header("X-Requested-With", "XMLHttpRequest")
+		.json_owned()
+}
+
+/// Extract every chapter for a novel.
+///
+/// The novel page only renders the first page (40 chapters) of the chapter
+/// list; the remaining chapters are loaded on demand through an AJAX endpoint
+/// that reports the total number of pages. Walk every page so the full list is
+/// returned, newest chapter first.
+pub fn extract_chapters(slug: &str) -> Result<Vec<Chapter>> {
+	let mut chapters = Vec::new();
+	let first = fetch_chapter_page(slug, 1)?;
+	collect_chapter_items(&first.html, &mut chapters);
+	for page in 2..=first.total_page.max(1) {
+		let response = fetch_chapter_page(slug, page)?;
+		collect_chapter_items(&response.html, &mut chapters);
+	}
+	// The endpoint lists chapters oldest-first across pages; reverse so the
+	// newest chapter comes first.
+	chapters.reverse();
+	Ok(chapters)
+}
+
+/// Parse an HTML fragment of `<li>` chapter items and append them to `chapters`.
+fn collect_chapter_items(html: &str, chapters: &mut Vec<Chapter>) {
+	let Ok(document) = Html::parse_fragment_with_url(html, BASE_URL) else {
+		return;
 	};
-	items
-		.rev()
-		.filter_map(|item| {
-			let link = item.select_first("a[href]")?;
-			let url = link.attr("abs:href")?;
-			let (_, chapter_key) = parse_novel_and_chapter(&url)?;
-			let chapter_key = chapter_key?;
-			let mut title = link.text()?;
-			let chapter_number = parse_chapter_number(&title);
-			if let Some(chapter_number) = chapter_number {
-				title = match title.strip_prefix(&format!("Chapter {chapter_number}")) {
-					Some(rest) => rest
-						.trim()
-						.strip_prefix(':')
-						.or_else(|| rest.trim().strip_prefix('-'))
-						.map_or_else(|| rest.trim().to_string(), |t| t.trim().to_string()),
-					None => title,
-				};
-			};
-			Some(Chapter {
-				key: chapter_key,
-				title: { if !title.is_empty() { Some(title) } else { None } },
-				chapter_number,
-				url: Some(url),
-				..Default::default()
-			})
-		})
-		.collect()
+	let Some(items) = document.select("li") else {
+		return;
+	};
+	for item in items {
+		if let Some(chapter) = parse_chapter_item(&item) {
+			chapters.push(chapter);
+		}
+	}
+}
+
+/// Build a [`Chapter`] from a single `<li>` chapter item.
+fn parse_chapter_item(item: &Element) -> Option<Chapter> {
+	let link = item.select_first("a[href]")?;
+	let url = link.attr("abs:href")?;
+	let (_, chapter_key) = parse_novel_and_chapter(&url)?;
+	let chapter_key = chapter_key?;
+	let mut title = link.text()?;
+	let chapter_number = parse_chapter_number(&title);
+	if let Some(chapter_number) = chapter_number {
+		title = match title.strip_prefix(&format!("Chapter {chapter_number}")) {
+			Some(rest) => rest
+				.trim()
+				.strip_prefix(':')
+				.or_else(|| rest.trim().strip_prefix('-'))
+				.map_or_else(|| rest.trim().to_string(), |t| t.trim().to_string()),
+			None => title,
+		};
+	};
+	Some(Chapter {
+		key: chapter_key,
+		title: { if !title.is_empty() { Some(title) } else { None } },
+		chapter_number,
+		url: Some(url),
+		..Default::default()
+	})
 }
 
 fn convert_element_to_markdown(element: &Element, output: &mut String) {

--- a/sources/en.freewebnovel/src/helpers.rs
+++ b/sources/en.freewebnovel/src/helpers.rs
@@ -65,25 +65,14 @@ pub fn parse_novel_and_chapter(url: &str) -> Option<(String, Option<String>)> {
 	Some((slug, chapter_key))
 }
 
+/// Parse the leading chapter number from a title like "Chapter 12.5: ...".
+/// Returns `None` when the title isn't a "Chapter <number>" label.
 pub fn parse_chapter_number(name: &str) -> Option<f32> {
-	let mut chapter = None;
-	let mut name = name.trim();
-	if name.starts_with("Chapter") {
-		name = name[7..].trim_start();
-		let bytes = name.as_bytes();
-		let mut ch_end = 0;
-		while ch_end < bytes.len()
-			&& ((bytes[ch_end] as char).is_ascii_digit() || (bytes[ch_end] as char) == '.')
-		{
-			ch_end += 1;
-		}
-		if ch_end > 0
-			&& let Ok(c) = name[..ch_end].parse::<f32>()
-		{
-			chapter = Some(c);
-		}
-	}
-	chapter
+	let digits = name.trim().strip_prefix("Chapter")?.trim_start();
+	let end = digits
+		.find(|c: char| !c.is_ascii_digit() && c != '.')
+		.unwrap_or(digits.len());
+	digits[..end].parse().ok()
 }
 
 pub fn content_rating_from_tags(tags: &[String]) -> ContentRating {
@@ -107,6 +96,8 @@ struct ChapterListResponse {
 	html: String,
 	/// Total number of chapter pages for the current `pageSize`.
 	total_page: i32,
+	/// Total number of chapters across every page.
+	total_chapters: i32,
 }
 
 /// Fetch a single page of the chapter list through the AJAX endpoint.
@@ -125,8 +116,8 @@ fn fetch_chapter_page(slug: &str, page: i32) -> Result<ChapterListResponse> {
 /// that reports the total number of pages. Walk every page so the full list is
 /// returned, newest chapter first.
 pub fn extract_chapters(slug: &str) -> Result<Vec<Chapter>> {
-	let mut chapters = Vec::new();
 	let first = fetch_chapter_page(slug, 1)?;
+	let mut chapters = Vec::with_capacity(first.total_chapters.max(0) as usize);
 	collect_chapter_items(&first.html, &mut chapters);
 	for page in 2..=first.total_page.max(1) {
 		let response = fetch_chapter_page(slug, page)?;
@@ -153,27 +144,31 @@ fn collect_chapter_items(html: &str, chapters: &mut Vec<Chapter>) {
 	}
 }
 
+/// Strip a leading "Chapter N" label and its `:`/`-` separator from a title,
+/// leaving just the subtitle. Returns `None` when the title doesn't start with
+/// that exact label, so the caller can keep the original title.
+fn strip_chapter_label(title: &str, number: f32) -> Option<String> {
+	let rest = title.strip_prefix(&format!("Chapter {number}"))?.trim();
+	let rest = rest.strip_prefix([':', '-']).unwrap_or(rest).trim();
+	Some(rest.to_string())
+}
+
 /// Build a [`Chapter`] from a single `<li>` chapter item.
 fn parse_chapter_item(item: &Element) -> Option<Chapter> {
 	let link = item.select_first("a[href]")?;
 	let url = link.attr("abs:href")?;
 	let (_, chapter_key) = parse_novel_and_chapter(&url)?;
 	let chapter_key = chapter_key?;
-	let mut title = link.text()?;
-	let chapter_number = parse_chapter_number(&title);
-	if let Some(chapter_number) = chapter_number {
-		title = match title.strip_prefix(&format!("Chapter {chapter_number}")) {
-			Some(rest) => rest
-				.trim()
-				.strip_prefix(':')
-				.or_else(|| rest.trim().strip_prefix('-'))
-				.map_or_else(|| rest.trim().to_string(), |t| t.trim().to_string()),
-			None => title,
-		};
-	};
+
+	let raw_title = link.text()?;
+	let chapter_number = parse_chapter_number(&raw_title);
+	let title = chapter_number
+		.and_then(|number| strip_chapter_label(&raw_title, number))
+		.unwrap_or(raw_title);
+
 	Some(Chapter {
 		key: chapter_key,
-		title: { if !title.is_empty() { Some(title) } else { None } },
+		title: (!title.is_empty()).then_some(title),
 		chapter_number,
 		url: Some(url),
 		..Default::default()
@@ -445,4 +440,34 @@ fn find_cover_image(el: &Element) -> Option<String> {
 		.and_then(|img| img.attr("abs:src"))
 		.or_else(|| el.select_first("img").and_then(|img| img.attr("abs:src")));
 	cover.and_then(|url| normalize_cover_url(&url))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use aidoku_test::aidoku_test;
+
+	#[aidoku_test]
+	fn parses_chapter_number() {
+		assert_eq!(parse_chapter_number("Chapter 40: Foo"), Some(40.0));
+		assert_eq!(parse_chapter_number("Chapter 12.5"), Some(12.5));
+		assert_eq!(parse_chapter_number("Prologue"), None);
+		assert_eq!(parse_chapter_number("Chapter"), None);
+	}
+
+	#[aidoku_test]
+	fn strips_chapter_label() {
+		assert_eq!(
+			strip_chapter_label("Chapter 40: Foo", 40.0).as_deref(),
+			Some("Foo")
+		);
+		assert_eq!(
+			strip_chapter_label("Chapter 7 - Bar", 7.0).as_deref(),
+			Some("Bar")
+		);
+		// A label with no subtitle collapses to an empty string.
+		assert_eq!(strip_chapter_label("Chapter 40", 40.0).as_deref(), Some(""));
+		// A formatting mismatch keeps the caller's original title.
+		assert_eq!(strip_chapter_label("Chapter 07", 7.0), None);
+	}
 }

--- a/sources/en.freewebnovel/src/lib.rs
+++ b/sources/en.freewebnovel/src/lib.rs
@@ -54,10 +54,8 @@ impl Source for FreeWebNovel {
 		needs_details: bool,
 		needs_chapters: bool,
 	) -> Result<Manga> {
-		let url = build_novel_url(&manga.key);
-		let html = request_html(&url)?;
-
 		if needs_details {
+			let html = request_html(&build_novel_url(&manga.key))?;
 			manga = fill_manga_details(&html, manga)?;
 			if needs_chapters {
 				send_partial_result(&manga);
@@ -65,8 +63,7 @@ impl Source for FreeWebNovel {
 		}
 
 		if needs_chapters {
-			let chapters = extract_chapters(&html);
-			manga.chapters = Some(chapters);
+			manga.chapters = Some(extract_chapters(&manga.key)?);
 		}
 
 		Ok(manga)


### PR DESCRIPTION
## Firstly
This is completely vibe-coded. I made this PR for anyone who wants to use this source right away.

## What
FreeWebNovel only loaded the first 40 chapters of any novel. The novel detail
page renders just page 1 (40 chapters) of the chapter list; the remaining
chapters are served on demand through an AJAX endpoint.

`extract_chapters` now paginates `/novel/{slug}?ajax=chapters&page=N&pageSize=200`
(header `X-Requested-With: XMLHttpRequest`), reads the authoritative `totalPage`
from the first JSON response, and parses each returned `<li>` HTML fragment — so
the complete chapter list is returned, newest chapter first.

## Why
Reported bug #600: only the first 40 chapters appear. Root cause is the site's
server-side pagination of the chapter list (≤200 per page).

## Commits
- **fix:** load all chapters via the AJAX pagination endpoint.
- **refactor:** simplify the chapter parsing (no behavior change) — rewrite
  `parse_chapter_number` with `strip_prefix`/`find`/`parse`, extract a testable
  `strip_chapter_label` helper, pre-size the `Vec` from `totalChapters`, and add
  hermetic unit tests for the pure helpers.

## Notes for reviewer
- Added the `aidoku` `json` feature + `serde` to deserialize the AJAX response.
- `get_manga_update` now fetches the detail page only when `needs_details`,
  avoiding a wasted request on chapter-only refreshes.
- Bumped `source.json` version 2 → 3.
- Chapter pages are fetched **sequentially on purpose**: the site (Cloudflare)
  rate-limits bursts of parallel requests, so `send_all` was avoided.
- Tests hit the live site — run `cargo test -- --test-threads=1` (parallel runs
  trip the rate-limiting and fail with `RequestError`). All 8 pass; the test
  novel now returns 809 chapters instead of 40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)