### PR TITLE
feat(multi.suwayomi): add user and password support (fix for pull 223)

### DIFF
--- a/sources/multi.suwayomi/Cargo.lock
+++ b/sources/multi.suwayomi/Cargo.lock
@@ -41,6 +41,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +300,7 @@ name = "suwayomi"
 version = "0.1.0"
 dependencies = [
  "aidoku",
+ "base64",
  "serde",
  "serde_json",
 ]

--- a/sources/multi.suwayomi/Cargo.toml
+++ b/sources/multi.suwayomi/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", version = "0.3.0", features = ["json"] }
 serde = { version = "1.0", features = ["derive"], default-features = false }
 serde_json = { version = "1.0.143", default-features = false, features = ["alloc"] }
+base64 = { version = "0.22", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", features = ["test"] }

--- a/sources/multi.suwayomi/res/settings.json
+++ b/sources/multi.suwayomi/res/settings.json
@@ -11,7 +11,30 @@
 				"returnKeyType": 9,
 				"autocorrectionDisabled": true,
 				"refreshes": ["content"]
+			},
+			{
+				"type": "select",
+				"key": "authMode",
+				"title": "Auth Mode",
+				"values": ["auto", "none", "basic_auth", "simple_login"],
+				"titles": [
+					"Auto",
+					"None",
+					"Basic Auth",
+					"Simple Login"
+				],
+				"default": "auto",
+				"refreshes": ["content"]
+			},
+			{
+				"type": "login",
+				"method": "basic",
+				"key": "credentials",
+				"title": "Login",
+				"requires": "baseUrl",
+				"refreshes": ["content"]
 			}
-		]
+		],
+		"footer": "Enter your Suwayomi server URL and optionally login with your credentials."
 	}
 ]

--- a/sources/multi.suwayomi/res/settings.json
+++ b/sources/multi.suwayomi/res/settings.json
@@ -32,7 +32,7 @@
 				"key": "credentials",
 				"title": "Login",
 				"requires": "baseUrl",
-				"refreshes": ["content"]
+				"refreshes": ["content", "listings"]
 			}
 		],
 		"footer": "Enter your Suwayomi server URL and optionally login with your credentials."

--- a/sources/multi.suwayomi/res/settings.json
+++ b/sources/multi.suwayomi/res/settings.json
@@ -30,7 +30,7 @@
 				"type": "login",
 				"method": "basic",
 				"key": "credentials",
-				"title": "Login",
+				"title": "LOGIN",
 				"requires": "baseUrl",
 				"refreshes": ["content", "listings"]
 			}

--- a/sources/multi.suwayomi/res/source.json
+++ b/sources/multi.suwayomi/res/source.json
@@ -2,7 +2,7 @@
 	"info": {
 		"id": "multi.suwayomi",
 		"name": "Suwayomi",
-		"version": 3,
+		"version": 4,
 		"url": "https://github.com/Suwayomi",
 		"contentRating": 0,
 		"languages": [

--- a/sources/multi.suwayomi/src/lib.rs
+++ b/sources/multi.suwayomi/src/lib.rs
@@ -13,14 +13,15 @@ use crate::models::{
 };
 use aidoku::imports::std::send_partial_result;
 use aidoku::{
-	AidokuError, BaseUrlProvider, Chapter, DynamicListings, FilterValue, Listing, ListingProvider,
-	Manga, MangaPageResult, Page, PageContent, Result, Source,
+	AidokuError, BaseUrlProvider, BasicLoginHandler, Chapter, DynamicListings, FilterValue,
+	Listing, ListingProvider, Manga, MangaPageResult, Page, PageContent, Result, Source,
 	alloc::{String, Vec},
 	imports::net::Request,
 	prelude::*,
 };
 use alloc::string::ToString;
 use alloc::vec;
+use base64::{Engine, engine::general_purpose::STANDARD};
 
 struct Suwayomi;
 
@@ -30,10 +31,53 @@ impl Suwayomi {
 		T: serde::de::DeserializeOwned,
 	{
 		let base_url = settings::get_base_url()?;
-		Request::post(format!("{base_url}/api/graphql"))?
-			.header("Content-Type", "application/json")
-			.body(body.to_string())
-			.json_owned::<GraphQLResponse<T>>()
+		let auth_mode = settings::get_auth_mode();
+		let body_str = body.to_string();
+
+		let send_req = |with_basic: bool| -> Result<GraphQLResponse<T>> {
+			let mut request = Request::post(format!("{base_url}/api/graphql"))?
+				.header("Content-Type", "application/json")
+				.body(body_str.clone());
+
+			if with_basic && let Some((user, pass)) = settings::get_credentials() {
+				let auth = STANDARD.encode(format!("{user}:{pass}"));
+				request = request.header("Authorization", &format!("Basic {auth}"));
+			}
+			request.json_owned::<GraphQLResponse<T>>()
+		};
+
+		let do_login_html = || -> Result<()> {
+			if let Some((user, pass)) = settings::get_credentials() {
+				let form = format!(
+					"user={}&pass={}",
+					aidoku::helpers::uri::encode_uri_component(user),
+					aidoku::helpers::uri::encode_uri_component(pass)
+				);
+				let _ = Request::post(format!("{base_url}/login.html"))?
+					.header("Content-Type", "application/x-www-form-urlencoded")
+					.body(form)
+					.send()
+					.ok();
+			}
+			Ok(())
+		};
+
+		match auth_mode.as_str() {
+			"none" => send_req(false),
+			"basic_auth" => send_req(true),
+			"simple_login" => {
+				do_login_html()?;
+				send_req(false)
+			}
+			_ => {
+				let resp = send_req(true);
+				if resp.is_err() {
+					do_login_html()?;
+					return send_req(true);
+				}
+				resp
+			}
+		}
 	}
 
 	fn execute_query<T>(
@@ -271,4 +315,69 @@ impl BaseUrlProvider for Suwayomi {
 	}
 }
 
-register_source!(Suwayomi, ListingProvider, BaseUrlProvider, DynamicListings);
+impl BasicLoginHandler for Suwayomi {
+	fn handle_basic_login(&self, _key: String, username: String, password: String) -> Result<bool> {
+		let base_url = settings::get_base_url()?;
+		let auth_mode = settings::get_auth_mode();
+
+		let send_basic_req = || {
+			let auth = STANDARD.encode(format!("{username}:{password}"));
+			let body = serde_json::json!({
+				"operationName": graphql::GraphQLQuery::CATEGORIES.operation_name,
+				"query": graphql::GraphQLQuery::CATEGORIES.query,
+			});
+			Request::post(format!("{base_url}/api/graphql"))?
+				.header("Content-Type", "application/json")
+				.header("Authorization", &format!("Basic {auth}"))
+				.body(body.to_string())
+				.send()
+		};
+
+		let send_form_req = || {
+			let form = format!(
+				"user={}&pass={}",
+				aidoku::helpers::uri::encode_uri_component(username.clone()),
+				aidoku::helpers::uri::encode_uri_component(password.clone())
+			);
+			Request::post(format!("{base_url}/login.html"))?
+				.header("Content-Type", "application/x-www-form-urlencoded")
+				.body(form)
+				.send()
+		};
+
+		match auth_mode.as_str() {
+			"none" => Ok(true),
+			"basic_auth" => {
+				let resp = send_basic_req()?;
+				Ok(resp.status_code() == 200)
+			}
+			"simple_login" => {
+				let resp = send_form_req()?;
+				Ok(resp.status_code() == 200)
+			}
+			_ => {
+				// auto: try basic auth first
+				if let Ok(resp) = send_basic_req()
+					&& resp.status_code() == 200
+				{
+					return Ok(true);
+				}
+				// try form login next
+				if let Ok(resp) = send_form_req()
+					&& resp.status_code() == 200
+				{
+					return Ok(true);
+				}
+				Ok(false)
+			}
+		}
+	}
+}
+
+register_source!(
+	Suwayomi,
+	ListingProvider,
+	BaseUrlProvider,
+	DynamicListings,
+	BasicLoginHandler
+);

--- a/sources/multi.suwayomi/src/lib.rs
+++ b/sources/multi.suwayomi/src/lib.rs
@@ -26,6 +26,48 @@ use base64::{Engine, engine::general_purpose::STANDARD};
 struct Suwayomi;
 
 impl Suwayomi {
+	fn send_graphql_post_request(
+		&self,
+		base_url: &str,
+		body: String,
+	) -> core::result::Result<Request, aidoku::imports::net::RequestError> {
+		let req = Request::post(format!("{base_url}/api/graphql"))?
+			.header("Content-Type", "application/json")
+			.body(body);
+		Ok(req)
+	}
+
+	fn send_basic_auth_request(
+		&self,
+		base_url: &str,
+		user: &str,
+		pass: &str,
+		body: String,
+	) -> core::result::Result<Request, aidoku::imports::net::RequestError> {
+		let auth = STANDARD.encode(format!("{user}:{pass}"));
+		let req = self
+			.send_graphql_post_request(base_url, body)?
+			.header("Authorization", &format!("Basic {auth}"));
+		Ok(req)
+	}
+
+	fn send_form_login_request(
+		&self,
+		base_url: &str,
+		user: &str,
+		pass: &str,
+	) -> core::result::Result<Request, aidoku::imports::net::RequestError> {
+		let form = format!(
+			"user={}&pass={}",
+			aidoku::helpers::uri::encode_uri_component(user),
+			aidoku::helpers::uri::encode_uri_component(pass)
+		);
+		let req = Request::post(format!("{base_url}/login.html"))?
+			.header("Content-Type", "application/x-www-form-urlencoded")
+			.body(form);
+		Ok(req)
+	}
+
 	fn graphql_request<T>(&self, body: serde_json::Value) -> Result<GraphQLResponse<T>>
 	where
 		T: serde::de::DeserializeOwned,
@@ -35,27 +77,18 @@ impl Suwayomi {
 		let body_str = body.to_string();
 
 		let send_req = |with_basic: bool| -> Result<GraphQLResponse<T>> {
-			let mut request = Request::post(format!("{base_url}/api/graphql"))?
-				.header("Content-Type", "application/json")
-				.body(body_str.clone());
-
-			if with_basic && let Some((user, pass)) = settings::get_credentials() {
-				let auth = STANDARD.encode(format!("{user}:{pass}"));
-				request = request.header("Authorization", &format!("Basic {auth}"));
-			}
+			let request = if with_basic && let Some((user, pass)) = settings::get_credentials() {
+				self.send_basic_auth_request(&base_url, &user, &pass, body_str.clone())?
+			} else {
+				self.send_graphql_post_request(&base_url, body_str.clone())?
+			};
 			request.json_owned::<GraphQLResponse<T>>()
 		};
 
 		let do_login_html = || -> Result<()> {
 			if let Some((user, pass)) = settings::get_credentials() {
-				let form = format!(
-					"user={}&pass={}",
-					aidoku::helpers::uri::encode_uri_component(user),
-					aidoku::helpers::uri::encode_uri_component(pass)
-				);
-				let _ = Request::post(format!("{base_url}/login.html"))?
-					.header("Content-Type", "application/x-www-form-urlencoded")
-					.body(form)
+				let _ = self
+					.send_form_login_request(&base_url, &user, &pass)?
 					.send()
 					.ok();
 			}
@@ -321,27 +354,16 @@ impl BasicLoginHandler for Suwayomi {
 		let auth_mode = settings::get_auth_mode();
 
 		let send_basic_req = || {
-			let auth = STANDARD.encode(format!("{username}:{password}"));
 			let body = serde_json::json!({
 				"operationName": graphql::GraphQLQuery::CATEGORIES.operation_name,
 				"query": graphql::GraphQLQuery::CATEGORIES.query,
 			});
-			Request::post(format!("{base_url}/api/graphql"))?
-				.header("Content-Type", "application/json")
-				.header("Authorization", &format!("Basic {auth}"))
-				.body(body.to_string())
+			self.send_basic_auth_request(&base_url, &username, &password, body.to_string())?
 				.send()
 		};
 
 		let send_form_req = || {
-			let form = format!(
-				"user={}&pass={}",
-				aidoku::helpers::uri::encode_uri_component(username.clone()),
-				aidoku::helpers::uri::encode_uri_component(password.clone())
-			);
-			Request::post(format!("{base_url}/login.html"))?
-				.header("Content-Type", "application/x-www-form-urlencoded")
-				.body(form)
+			self.send_form_login_request(&base_url, &username, &password)?
 				.send()
 		};
 

--- a/sources/multi.suwayomi/src/settings.rs
+++ b/sources/multi.suwayomi/src/settings.rs
@@ -1,11 +1,28 @@
-use aidoku::{AidokuError, alloc::string::String, imports::defaults::defaults_get, prelude::bail};
+use aidoku::{Result, alloc::String, imports::defaults::defaults_get, prelude::*};
 
 const BASE_URL_KEY: &str = "baseUrl";
+const AUTH_MODE_KEY: &str = "authMode";
+const USERNAME_KEY: &str = "credentials.username";
+const PASSWORD_KEY: &str = "credentials.password";
 
-pub fn get_base_url() -> Result<String, AidokuError> {
-	let base_url = defaults_get::<String>(BASE_URL_KEY);
-	match base_url {
-		Some(url) if !url.is_empty() => Ok(url),
-		_ => bail!("Base Url not configured"),
+pub fn get_base_url() -> Result<String> {
+	let url: String = defaults_get::<String>(BASE_URL_KEY).ok_or(error!("Missing baseUrl"))?;
+	Ok(url.trim_end_matches('/').into())
+}
+
+pub fn get_auth_mode() -> String {
+	match defaults_get::<String>(AUTH_MODE_KEY) {
+		Some(v) if !v.is_empty() => v,
+		_ => "auto".into(),
 	}
+}
+
+pub fn get_credentials() -> Option<(String, String)> {
+	let user: String = defaults_get::<String>(USERNAME_KEY)?;
+	let pass: String = defaults_get::<String>(PASSWORD_KEY)?;
+
+	if user.is_empty() {
+		return None;
+	}
+	Some((user, pass))
 }


### PR DESCRIPTION
Closes #223

- [x] the source can be compiled without any warnings or errors.
- [x] cargo fmt has been run before submission.
- [x] cargo clippy outputs no lint warnings.
- [x] All files have an additional newline at the end.
- [x] JSON files use tabs for indentation.