### PR TITLE
chore(zh.copymanga): update base urls

### DIFF
--- a/sources/zh.copymanga/res/source.json
+++ b/sources/zh.copymanga/res/source.json
@@ -2,7 +2,7 @@
 	"info": {
 		"id": "zh.copymanga",
 		"name": "拷貝漫畫",
-		"version": 18,
+		"version": 19,
 		"urls": [
 			"https://www.copy3000.com",
 			"https://copy3000.com",

--- a/sources/zh.copymanga/res/source.json
+++ b/sources/zh.copymanga/res/source.json
@@ -4,6 +4,8 @@
 		"name": "拷貝漫畫",
 		"version": 18,
 		"urls": [
+			"https://www.copy3000.com",
+			"https://copy3000.com",
 			"https://www.2026copy.com",
 			"https://2026copy.com",
 			"https://www.2025copy.com",


### PR DESCRIPTION
Copymanga has announced a new domain for readers in the mainland of China to access directly.
https://www.copy3000.com

Old domains still work.