### PR TITLE
fix(en.novelbuddy): update url

### DIFF
--- a/sources/en.novelbuddy/res/source.json
+++ b/sources/en.novelbuddy/res/source.json
@@ -2,8 +2,8 @@
 	"info": {
 		"id": "en.novelbuddy",
 		"name": "NovelBuddy",
-		"version": 2,
-		"url": "https://novelbuddy.com",
+		"version": 3,
+		"url": "https://novelbuddy.me",
 		"contentRating": 1,
 		"languages": ["en"],
 		"minAppVersion": "0.7.1"

--- a/sources/en.novelbuddy/src/helpers.rs
+++ b/sources/en.novelbuddy/src/helpers.rs
@@ -15,7 +15,7 @@ pub fn request<T: DeserializeOwned>(url: &str) -> Result<T> {
 	let response = Request::get(url)?
 		.header("User-Agent", USER_AGENT)
 		.header("Accept", "application/json, text/plain, */*")
-		.header("Referer", "https://novelbuddy.com/")
+		.header("Referer", "https://novelbuddy.me/")
 		.header("Origin", BASE_URL)
 		.json_owned::<ApiResponse<T>>()?;
 	if !response.success {

--- a/sources/en.novelbuddy/src/lib.rs
+++ b/sources/en.novelbuddy/src/lib.rs
@@ -14,8 +14,8 @@ mod models;
 use helpers::{fetch_chapter_list, request, resolve_slug};
 use models::{ChapterDetailData, ListData, TitleDetailData, TrendingData};
 
-pub const BASE_URL: &str = "https://novelbuddy.com";
-pub const API_URL: &str = "https://api.novelbuddy.com";
+pub const BASE_URL: &str = "https://novelbuddy.me";
+pub const API_URL: &str = "https://api.novelbuddy.me";
 pub const USER_AGENT: &str = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 \
 	 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1";
 
@@ -163,7 +163,7 @@ impl DeepLinkHandler for NovelBuddy {
 			.split(['?', '#'])
 			.next()
 			.unwrap_or(&url)
-			.rsplit("novelbuddy.com")
+			.rsplit("novelbuddy.me")
 			.next()
 			.unwrap_or("")
 			.trim_start_matches('/');
@@ -274,7 +274,7 @@ mod tests {
 	fn deep_link_resolves_series() {
 		let source = NovelBuddy;
 		let result = source
-			.handle_deep_link("https://novelbuddy.com/shadow-slave".into())
+			.handle_deep_link("https://novelbuddy.me/shadow-slave".into())
 			.expect("deep link failed")
 			.expect("expected Some(DeepLinkResult)");
 		match result {


### PR DESCRIPTION
## Description

NovelBuddy has redesigned their site and migrated from `novelbuddy.com` to `novelbuddy.me`. The old domain now returns 404s on API requests, so the `en.novelbuddy` source is currently broken.

## Evidence

Requesting the old API domain now fails:
```
curl https://api.novelbuddy.com/titles/by-slug/shadow-slave
```
```
404 Not Found
```

The new domain works and returns the same response shape as before:
```
curl https://api.novelbuddy.me/titles/by-slug/shadow-slave
```
```
{"success":true,"data":{"new_url":"/titles/VYPGVZ8z-shadow-slave"}}
```

The frontend URL scheme (`novelbuddy.me/{slug}` and `novelbuddy.me/{slug}/{chapter-slug}`) and the API JSON schema are otherwise unchanged.

## Fix

Swapped `.com` for `.me` in `BASE_URL` and `API_URL` in `src/lib.rs`, the `Referer` header in `helpers.rs`, and `url` in `res/source.json` (plus a `source.json` version bump so Aidoku picks up the update). No other logic changed.

Closes #617
