### PR TITLE
fix(zh.dm5): send isAdult cookie to unlock restricted series

### DIFF
--- a/sources/zh.dm5/res/source.json
+++ b/sources/zh.dm5/res/source.json
@@ -2,7 +2,7 @@
 	"info": {
 		"id": "zh.dm5",
 		"name": "动漫屋",
-		"version": 1,
+		"version": 2,
 		"urls": [
 			"https://www.dm5.com",
 			"https://www.dm5.cn"

--- a/sources/zh.dm5/src/html/mod.rs
+++ b/sources/zh.dm5/src/html/mod.rs
@@ -217,6 +217,9 @@ pub fn get_page_list(chapter_key: &str) -> Result<Vec<Page>> {
 		)
 		.header("Referer", BASE_URL)
 		.header("DNT", "1")
+		// Restricted series gate their reader pages behind the same consent
+		// cookie the chapter list needs (see net::Url::request).
+		.header("Cookie", "isAdult=1")
 		.html()?;
 
 	let mut pages: Vec<Page> = Vec::new();

--- a/sources/zh.dm5/src/net/mod.rs
+++ b/sources/zh.dm5/src/net/mod.rs
@@ -91,7 +91,10 @@ impl Url {
 				"Accept",
 				"text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
 			)
-			.header("Referer", BASE_URL))
+			.header("Referer", BASE_URL)
+			// Restricted (限制漫画) series replace their chapter list with an
+			// age-gate warning page unless this consent cookie is present.
+			.header("Cookie", "isAdult=1"))
 	}
 }
 


### PR DESCRIPTION
Restricted (限制漫画) series on dm5 never return a chapter list, so opening one
fails with `Chapter list not found`.

For these series the site replaces the chapter list with an age-gate warning
page ("已被列为限制漫画 ... 我们将对 XXX 进行屏蔽") unless the `isAdult=1` consent
cookie is set. The banner is still present on that page, so details and search
parse fine and only `chapters()` fails — `div#chapterlistload` simply isn't
there.

Sending `isAdult=1` returns the normal detail page. This matches what
`zh.manhuagui` already does (`device_view=pc; isAdult=1`).

The cookie is added to `net::Url::request` (covers search, filters, and the
detail page that chapters are parsed from), and to the reader-page request in
`get_page_list` for consistency.

## Reproduction

`manhua-yishoumodu` (异兽魔都), which is flagged as restricted. The gate is
locale-dependent, so this needs the same `User-Agent` and `Accept-Language`
the source already sends:

```
$ UA="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36"

$ curl -s -A "$UA" -H "Accept-Language: zh-TW" \
    "https://www.dm5.com/manhua-yishoumodu/" | grep -c chapterlistload
0

$ curl -s -A "$UA" -H "Accept-Language: zh-TW" -H "Cookie: isAdult=1" \
    "https://www.dm5.com/manhua-yishoumodu/" | grep -c chapterlistload
1
```

Before: `Chapter list not found`. After: 69 chapters, details unchanged.
Non-restricted series are unaffected.
