### PR TITLE
feat(multi.suwayomi): add ui_login support and authenticated image loading

### DIFF
--- a/sources/multi.suwayomi/res/settings.json
+++ b/sources/multi.suwayomi/res/settings.json
@@ -16,12 +16,13 @@
 				"type": "select",
 				"key": "authMode",
 				"title": "Auth Mode",
-				"values": ["auto", "none", "basic_auth", "simple_login"],
+				"values": ["auto", "none", "basic_auth", "simple_login", "ui_login"],
 				"titles": [
 					"Auto",
 					"None",
 					"Basic Auth",
-					"Simple Login"
+					"Simple Login",
+					"UI Login"
 				],
 				"default": "auto",
 				"refreshes": ["content"]

--- a/sources/multi.suwayomi/res/source.json
+++ b/sources/multi.suwayomi/res/source.json
@@ -2,7 +2,7 @@
 	"info": {
 		"id": "multi.suwayomi",
 		"name": "Suwayomi",
-		"version": 4,
+		"version": 5,
 		"url": "https://github.com/Suwayomi",
 		"contentRating": 0,
 		"languages": [

--- a/sources/multi.suwayomi/src/lib.rs
+++ b/sources/multi.suwayomi/src/lib.rs
@@ -11,30 +11,43 @@ use crate::models::{
 	FetchChapterPagesResponse, GraphQLResponse, MangaOnlyDescriptionResponse, MultipleCategories,
 	MultipleChapters, MultipleMangas,
 };
-use aidoku::imports::std::send_partial_result;
+use aidoku::imports::std::{current_date, send_partial_result};
 use aidoku::{
 	AidokuError, BaseUrlProvider, BasicLoginHandler, Chapter, DynamicListings, FilterValue,
-	Listing, ListingProvider, Manga, MangaPageResult, Page, PageContent, Result, Source,
+	ImageRequestProvider, Listing, ListingProvider, Manga, MangaPageResult, Page, PageContent, PageContext,
+	Result, Source,
 	alloc::{String, Vec},
 	imports::net::Request,
 	prelude::*,
 };
 use alloc::string::ToString;
 use alloc::vec;
-use base64::{Engine, engine::general_purpose::STANDARD};
+use base64::{Engine, engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD}};
 
 struct Suwayomi;
 
 impl Suwayomi {
+	fn send_graphql_token_request(
+		&self,
+		base_url: &str,
+		token: Option<String>,
+		body: String,
+	) -> core::result::Result<Request, aidoku::imports::net::RequestError> {
+		let mut req = Request::post(format!("{base_url}/api/graphql"))?
+			.header("Content-Type", "application/json");
+		if let Some(t) = token {
+			req = req.header("Authorization", &format!("Bearer {t}"));
+		}
+		let req = req.body(body);
+		Ok(req)
+	}
+
 	fn send_graphql_post_request(
 		&self,
 		base_url: &str,
 		body: String,
 	) -> core::result::Result<Request, aidoku::imports::net::RequestError> {
-		let req = Request::post(format!("{base_url}/api/graphql"))?
-			.header("Content-Type", "application/json")
-			.body(body);
-		Ok(req)
+		self.send_graphql_token_request(base_url, None, body)
 	}
 
 	fn send_basic_auth_request(
@@ -68,6 +81,80 @@ impl Suwayomi {
 		Ok(req)
 	}
 
+	fn perform_ui_login(&self, base_url: &str, user: &str, pass: &str) -> Result<()> {
+		let mutation = serde_json::json!({
+			"query": "mutation Login($input: LoginInput!) { login(input: $input) { accessToken refreshToken } }",
+			"variables": {
+				"input": {
+					"username": user,
+					"password": pass
+				}
+			}
+		});
+
+		let resp = Request::post(format!("{base_url}/api/graphql"))?
+			.header("Content-Type", "application/json")
+			.body(mutation.to_string())
+			.json_owned::<GraphQLResponse<serde_json::Value>>()?;
+
+		let login_payload = resp.data.get("login").ok_or_else(|| aidoku::error!("Missing login payload"))?;
+		let access_token = login_payload.get("accessToken").and_then(|v| v.as_str()).ok_or_else(|| aidoku::error!("Missing accessToken"))?;
+		let refresh_token = login_payload.get("refreshToken").and_then(|v| v.as_str()).ok_or_else(|| aidoku::error!("Missing refreshToken"))?;
+
+		settings::set_tokens(access_token, refresh_token);
+		Ok(())
+	}
+
+	fn perform_token_refresh(&self, base_url: &str, refresh_token: &str) -> Result<String> {
+		let mutation = serde_json::json!({
+			"query": "mutation Refresh($input: RefreshTokenInput!) { refreshToken(input: $input) { accessToken } }",
+			"variables": {
+				"input": {
+					"refreshToken": refresh_token
+				}
+			}
+		});
+
+		let resp = Request::post(format!("{base_url}/api/graphql"))?
+			.header("Content-Type", "application/json")
+			.body(mutation.to_string())
+			.json_owned::<GraphQLResponse<serde_json::Value>>()?;
+
+		let payload = resp.data.get("refreshToken").ok_or_else(|| aidoku::error!("Missing refreshToken payload"))?;
+		let access_token = payload.get("accessToken").and_then(|v| v.as_str()).ok_or_else(|| aidoku::error!("Missing accessToken"))?;
+
+		settings::set_access_token(access_token);
+		Ok(access_token.into())
+	}
+
+	fn get_valid_access_token(&self, base_url: &str) -> Result<String> {
+		if settings::get_credentials().is_none() {
+			settings::clear_tokens();
+			return Err(aidoku::error!("Not authenticated"));
+		}
+
+		if let Some(token) = settings::get_access_token() {
+			if !is_token_expired(&token) {
+				return Ok(token);
+			}
+		}
+
+		if let Some(refresh_token) = settings::get_refresh_token() {
+			if let Ok(new_token) = self.perform_token_refresh(base_url, &refresh_token) {
+				return Ok(new_token);
+			}
+		}
+
+		if let Some((user, pass)) = settings::get_credentials() {
+			self.perform_ui_login(base_url, &user, &pass)?;
+			if let Some(new_token) = settings::get_access_token() {
+				return Ok(new_token);
+			}
+		}
+
+		Err(aidoku::error!("Not authenticated"))
+	}
+
 	fn graphql_request<T>(&self, body: serde_json::Value) -> Result<GraphQLResponse<T>>
 	where
 		T: serde::de::DeserializeOwned,
@@ -76,8 +163,10 @@ impl Suwayomi {
 		let auth_mode = settings::get_auth_mode();
 		let body_str = body.to_string();
 
-		let send_req = |with_basic: bool| -> Result<GraphQLResponse<T>> {
-			let request = if with_basic && let Some((user, pass)) = settings::get_credentials() {
+		let send_req = |with_basic: bool, token: Option<String>| -> Result<GraphQLResponse<T>> {
+			let request = if let Some(t) = token {
+				self.send_graphql_token_request(&base_url, Some(t), body_str.clone())?
+			} else if with_basic && let Some((user, pass)) = settings::get_credentials() {
 				self.send_basic_auth_request(&base_url, &user, &pass, body_str.clone())?
 			} else {
 				self.send_graphql_post_request(&base_url, body_str.clone())?
@@ -96,17 +185,45 @@ impl Suwayomi {
 		};
 
 		match auth_mode.as_str() {
-			"none" => send_req(false),
-			"basic_auth" => send_req(true),
+			"none" => send_req(false, None),
+			"basic_auth" => send_req(true, None),
 			"simple_login" => {
 				do_login_html()?;
-				send_req(false)
+				send_req(false, None)
+			}
+			"ui_login" => {
+				let token = self.get_valid_access_token(&base_url)?;
+				let resp = send_req(false, Some(token));
+				if resp.is_err() {
+					settings::clear_tokens();
+					if let Ok(new_token) = self.get_valid_access_token(&base_url) {
+						send_req(false, Some(new_token))
+					} else {
+						resp
+					}
+				} else {
+					resp
+				}
 			}
 			_ => {
-				let resp = send_req(true);
+				// auto:
+				if let Ok(token) = self.get_valid_access_token(&base_url) {
+					let mut resp = send_req(false, Some(token));
+					if resp.is_ok() {
+						return resp;
+					}
+					settings::clear_tokens();
+					if let Ok(new_token) = self.get_valid_access_token(&base_url) {
+						resp = send_req(false, Some(new_token));
+						if resp.is_ok() {
+							return resp;
+						}
+					}
+				}
+				let resp = send_req(true, None);
 				if resp.is_err() {
 					do_login_html()?;
-					return send_req(true);
+					return send_req(true, None);
 				}
 				resp
 			}
@@ -131,6 +248,27 @@ impl Suwayomi {
 		}
 
 		self.graphql_request(body)
+	}
+}
+
+fn get_jwt_exp(token: &str) -> Option<u64> {
+	let mut parts = token.split('.');
+	let _header = parts.next()?;
+	let payload_b64 = parts.next()?;
+
+	let decoded = URL_SAFE_NO_PAD.decode(payload_b64).ok()?;
+	let decoded_str = core::str::from_utf8(&decoded).ok()?;
+	let json: serde_json::Value = serde_json::from_str(decoded_str).ok()?;
+	let exp = json.get("exp")?.as_u64()?;
+	Some(exp)
+}
+
+fn is_token_expired(token: &str) -> bool {
+	if let Some(exp) = get_jwt_exp(token) {
+		let now = current_date() as u64;
+		now + 10 >= exp
+	} else {
+		true
 	}
 }
 
@@ -367,6 +505,10 @@ impl BasicLoginHandler for Suwayomi {
 				.send()
 		};
 
+		let send_ui_login = || {
+			self.perform_ui_login(&base_url, &username, &password)
+		};
+
 		match auth_mode.as_str() {
 			"none" => Ok(true),
 			"basic_auth" => {
@@ -376,6 +518,9 @@ impl BasicLoginHandler for Suwayomi {
 			"simple_login" => {
 				let resp = send_form_req()?;
 				Ok(resp.status_code() == 200)
+			}
+			"ui_login" => {
+				Ok(send_ui_login().is_ok())
 			}
 			_ => {
 				// auto: try basic auth first
@@ -390,9 +535,48 @@ impl BasicLoginHandler for Suwayomi {
 				{
 					return Ok(true);
 				}
+				// try ui login next
+				if let Ok(_) = send_ui_login() {
+					return Ok(true);
+				}
 				Ok(false)
 			}
 		}
+	}
+}
+
+impl ImageRequestProvider for Suwayomi {
+	fn get_image_request(&self, url: String, _context: Option<PageContext>) -> Result<Request> {
+		let base_url = settings::get_base_url()?;
+		let auth_mode = settings::get_auth_mode();
+
+		let mut req = Request::get(url)?;
+
+		match auth_mode.as_str() {
+			"basic_auth" => {
+				if let Some((user, pass)) = settings::get_credentials() {
+					let auth = STANDARD.encode(format!("{user}:{pass}"));
+					req = req.header("Authorization", &format!("Basic {auth}"));
+				}
+			}
+			"ui_login" => {
+				if let Ok(token) = self.get_valid_access_token(&base_url) {
+					req = req.header("Authorization", &format!("Bearer {token}"));
+				}
+			}
+			"none" | "simple_login" => {}
+			_ => {
+				// auto:
+				if let Ok(token) = self.get_valid_access_token(&base_url) {
+					req = req.header("Authorization", &format!("Bearer {token}"));
+				} else if let Some((user, pass)) = settings::get_credentials() {
+					let auth = STANDARD.encode(format!("{user}:{pass}"));
+					req = req.header("Authorization", &format!("Basic {auth}"));
+				}
+			}
+		}
+
+		Ok(req)
 	}
 }
 
@@ -401,5 +585,34 @@ register_source!(
 	ListingProvider,
 	BaseUrlProvider,
 	DynamicListings,
-	BasicLoginHandler
+	BasicLoginHandler,
+	ImageRequestProvider
 );
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[unsafe(no_mangle)]
+	extern "C" fn current_date() -> f64 {
+		// Mock current time: 1782200000
+		1782200000.0
+	}
+
+	#[test]
+	fn test_jwt_expiry() {
+		// {"exp":1782297600} -> eyJleHAiOjE3ODIyOTc2MDB9
+		let mock_token = "header.eyJleHAiOjE3ODIyOTc2MDB9.signature";
+		assert_eq!(get_jwt_exp(mock_token), Some(1782297600));
+
+		// Test is_token_expired
+		// 1782297600 is in the far future relative to 1782200000, so it shouldn't be expired
+		assert!(!is_token_expired(mock_token));
+
+		// Test expired token (exp: 1000)
+		// {"exp":1000} -> eyJleHAiOjEwMDB9
+		let mock_expired_token = "header.eyJleHAiOjEwMDB9.signature";
+		assert_eq!(get_jwt_exp(mock_expired_token), Some(1000));
+		assert!(is_token_expired(mock_expired_token));
+	}
+}

--- a/sources/multi.suwayomi/src/lib.rs
+++ b/sources/multi.suwayomi/src/lib.rs
@@ -103,7 +103,7 @@ impl Suwayomi {
 		let login_payload = resp
 			.data
 			.get("login")
-			.ok_or_else(|| aidoku::error!("Missing login payload"))?;
+			.ok_or_else(|| error!("Missing login payload"))?;
 		let access_token = login_payload
 			.get("accessToken")
 			.and_then(|v| v.as_str())

--- a/sources/multi.suwayomi/src/lib.rs
+++ b/sources/multi.suwayomi/src/lib.rs
@@ -148,7 +148,7 @@ impl Suwayomi {
 	fn get_valid_access_token(&self, base_url: &str) -> Result<String> {
 		if settings::get_credentials().is_none() {
 			settings::clear_tokens();
-			return Err(aidoku::error!("Not authenticated"));
+			bail!("Not authenticated");
 		}
 
 		if let Some(token) = settings::get_access_token()

--- a/sources/multi.suwayomi/src/lib.rs
+++ b/sources/multi.suwayomi/src/lib.rs
@@ -14,15 +14,18 @@ use crate::models::{
 use aidoku::imports::std::{current_date, send_partial_result};
 use aidoku::{
 	AidokuError, BaseUrlProvider, BasicLoginHandler, Chapter, DynamicListings, FilterValue,
-	ImageRequestProvider, Listing, ListingProvider, Manga, MangaPageResult, Page, PageContent, PageContext,
-	Result, Source,
+	ImageRequestProvider, Listing, ListingProvider, Manga, MangaPageResult, Page, PageContent,
+	PageContext, Result, Source,
 	alloc::{String, Vec},
 	imports::net::Request,
 	prelude::*,
 };
 use alloc::string::ToString;
 use alloc::vec;
-use base64::{Engine, engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD}};
+use base64::{
+	Engine,
+	engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
+};
 
 struct Suwayomi;
 
@@ -97,9 +100,18 @@ impl Suwayomi {
 			.body(mutation.to_string())
 			.json_owned::<GraphQLResponse<serde_json::Value>>()?;
 
-		let login_payload = resp.data.get("login").ok_or_else(|| aidoku::error!("Missing login payload"))?;
-		let access_token = login_payload.get("accessToken").and_then(|v| v.as_str()).ok_or_else(|| aidoku::error!("Missing accessToken"))?;
-		let refresh_token = login_payload.get("refreshToken").and_then(|v| v.as_str()).ok_or_else(|| aidoku::error!("Missing refreshToken"))?;
+		let login_payload = resp
+			.data
+			.get("login")
+			.ok_or_else(|| aidoku::error!("Missing login payload"))?;
+		let access_token = login_payload
+			.get("accessToken")
+			.and_then(|v| v.as_str())
+			.ok_or_else(|| aidoku::error!("Missing accessToken"))?;
+		let refresh_token = login_payload
+			.get("refreshToken")
+			.and_then(|v| v.as_str())
+			.ok_or_else(|| aidoku::error!("Missing refreshToken"))?;
 
 		settings::set_tokens(access_token, refresh_token);
 		Ok(())
@@ -120,8 +132,14 @@ impl Suwayomi {
 			.body(mutation.to_string())
 			.json_owned::<GraphQLResponse<serde_json::Value>>()?;
 
-		let payload = resp.data.get("refreshToken").ok_or_else(|| aidoku::error!("Missing refreshToken payload"))?;
-		let access_token = payload.get("accessToken").and_then(|v| v.as_str()).ok_or_else(|| aidoku::error!("Missing accessToken"))?;
+		let payload = resp
+			.data
+			.get("refreshToken")
+			.ok_or_else(|| aidoku::error!("Missing refreshToken payload"))?;
+		let access_token = payload
+			.get("accessToken")
+			.and_then(|v| v.as_str())
+			.ok_or_else(|| aidoku::error!("Missing accessToken"))?;
 
 		settings::set_access_token(access_token);
 		Ok(access_token.into())
@@ -133,16 +151,16 @@ impl Suwayomi {
 			return Err(aidoku::error!("Not authenticated"));
 		}
 
-		if let Some(token) = settings::get_access_token() {
-			if !is_token_expired(&token) {
-				return Ok(token);
-			}
+		if let Some(token) = settings::get_access_token()
+			&& !is_token_expired(&token)
+		{
+			return Ok(token);
 		}
 
-		if let Some(refresh_token) = settings::get_refresh_token() {
-			if let Ok(new_token) = self.perform_token_refresh(base_url, &refresh_token) {
-				return Ok(new_token);
-			}
+		if let Some(refresh_token) = settings::get_refresh_token()
+			&& let Ok(new_token) = self.perform_token_refresh(base_url, &refresh_token)
+		{
+			return Ok(new_token);
 		}
 
 		if let Some((user, pass)) = settings::get_credentials() {
@@ -505,9 +523,7 @@ impl BasicLoginHandler for Suwayomi {
 				.send()
 		};
 
-		let send_ui_login = || {
-			self.perform_ui_login(&base_url, &username, &password)
-		};
+		let send_ui_login = || self.perform_ui_login(&base_url, &username, &password);
 
 		match auth_mode.as_str() {
 			"none" => Ok(true),
@@ -519,9 +535,7 @@ impl BasicLoginHandler for Suwayomi {
 				let resp = send_form_req()?;
 				Ok(resp.status_code() == 200)
 			}
-			"ui_login" => {
-				Ok(send_ui_login().is_ok())
-			}
+			"ui_login" => Ok(send_ui_login().is_ok()),
 			_ => {
 				// auto: try basic auth first
 				if let Ok(resp) = send_basic_req()
@@ -536,7 +550,7 @@ impl BasicLoginHandler for Suwayomi {
 					return Ok(true);
 				}
 				// try ui login next
-				if let Ok(_) = send_ui_login() {
+				if send_ui_login().is_ok() {
 					return Ok(true);
 				}
 				Ok(false)

--- a/sources/multi.suwayomi/src/settings.rs
+++ b/sources/multi.suwayomi/src/settings.rs
@@ -1,4 +1,9 @@
-use aidoku::{Result, alloc::String, imports::defaults::{defaults_get, defaults_set, DefaultValue}, prelude::*};
+use aidoku::{
+	Result,
+	alloc::String,
+	imports::defaults::{DefaultValue, defaults_get, defaults_set},
+	prelude::*,
+};
 
 const BASE_URL_KEY: &str = "baseUrl";
 const AUTH_MODE_KEY: &str = "authMode";

--- a/sources/multi.suwayomi/src/settings.rs
+++ b/sources/multi.suwayomi/src/settings.rs
@@ -1,9 +1,11 @@
-use aidoku::{Result, alloc::String, imports::defaults::defaults_get, prelude::*};
+use aidoku::{Result, alloc::String, imports::defaults::{defaults_get, defaults_set, DefaultValue}, prelude::*};
 
 const BASE_URL_KEY: &str = "baseUrl";
 const AUTH_MODE_KEY: &str = "authMode";
 const USERNAME_KEY: &str = "credentials.username";
 const PASSWORD_KEY: &str = "credentials.password";
+const ACCESS_TOKEN_KEY: &str = "credentials.accessToken";
+const REFRESH_TOKEN_KEY: &str = "credentials.refreshToken";
 
 pub fn get_base_url() -> Result<String> {
 	let url: String = defaults_get::<String>(BASE_URL_KEY).ok_or(error!("Missing baseUrl"))?;
@@ -25,4 +27,26 @@ pub fn get_credentials() -> Option<(String, String)> {
 		return None;
 	}
 	Some((user, pass))
+}
+
+pub fn get_access_token() -> Option<String> {
+	defaults_get::<String>(ACCESS_TOKEN_KEY)
+}
+
+pub fn get_refresh_token() -> Option<String> {
+	defaults_get::<String>(REFRESH_TOKEN_KEY)
+}
+
+pub fn set_tokens(access: &str, refresh: &str) {
+	defaults_set(ACCESS_TOKEN_KEY, DefaultValue::String(access.into()));
+	defaults_set(REFRESH_TOKEN_KEY, DefaultValue::String(refresh.into()));
+}
+
+pub fn set_access_token(access: &str) {
+	defaults_set(ACCESS_TOKEN_KEY, DefaultValue::String(access.into()));
+}
+
+pub fn clear_tokens() {
+	defaults_set(ACCESS_TOKEN_KEY, DefaultValue::Null);
+	defaults_set(REFRESH_TOKEN_KEY, DefaultValue::Null);
 }


### PR DESCRIPTION
![Alt Text](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNzVlOThlcGx5ZjdvdHo0aHRmZ2YwdHQ5OWppM3RkY3ZsNDlqMXJ1OCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Nx0rz3jtxtEre/giphy.gif)

v5 implements Suwayomi-server's JWT-based ui_login auth mode and fixes image loading when authentication is enabled on the server.
- Auth: Added ui_login option to settings and bumped version to 5.
- Token Management: Added storage helpers for access/refresh tokens.
- Implemented silent token refresh by base64url decoding the JWT payload to check the exp claim.
- Image Loading: Implemented ImageRequestProvider to append the appropriate auth headers (Basic or Bearer) to cover thumbnails and chapter pages.
- Robustness: If a request fails, the client clears the cached token and attempts a silent re-login/refresh once.
- Tests: Added unit tests to verify the JWT expiration parsing logic.

Tested compilation with aidoku-cli and ran tests via host target compilation.