### PR TITLE
fix(en.batcave): add auth handler

### DIFF
--- a/sources/en.batcave/Cargo.lock
+++ b/sources/en.batcave/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "aidoku"
 version = "0.3.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git#b0818704a5487778999bcd11239fa4c7a44da6ab"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#1a6bb691dd67c7151fc76fc852fb5a364d325f72"
 dependencies = [
  "euclid",
  "hashbrown",
@@ -22,10 +22,10 @@ dependencies = [
 [[package]]
 name = "aidoku-test"
 version = "1.0.0"
-source = "git+https://github.com/Aidoku/aidoku-rs.git#b0818704a5487778999bcd11239fa4c7a44da6ab"
+source = "git+https://github.com/Aidoku/aidoku-rs.git#1a6bb691dd67c7151fc76fc852fb5a364d325f72"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -45,9 +45,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "batcave"
@@ -55,7 +55,6 @@ version = "0.1.0"
 dependencies = [
  "aidoku",
  "aidoku-test",
- "regex",
  "serde",
  "serde_json",
 ]
@@ -101,9 +100,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "euclid"
-version = "0.22.11"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad9cdb4b747e485a12abb0e6566612956c7a1bafa3bdb8d682c5b6d403589e48"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
 ]
@@ -152,15 +151,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "lock_api"
@@ -173,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "num-traits"
@@ -208,46 +207,21 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "regex"
-version = "1.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
-dependencies = [
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
-dependencies = [
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rustc_version"
@@ -259,12 +233,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,15 +240,15 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -288,42 +256,42 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
@@ -336,9 +304,20 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"
-version = "2.0.107"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a26dbd934e5451d21ef060c018dae56fc073894c5a7896f882928a76e6d081b"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -356,26 +335,32 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.19"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/sources/en.batcave/Cargo.toml
+++ b/sources/en.batcave/Cargo.toml
@@ -3,18 +3,17 @@ name = "batcave"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", version = "0.3.0", features = ["json"] }
-regex = { version = "1.11.1", default-features = false }
 serde = { version = "1.0.188", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1.0.105", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 aidoku = { git = "https://github.com/Aidoku/aidoku-rs.git", features = ["test"] }
 aidoku-test = { git = "https://github.com/Aidoku/aidoku-rs.git" }
-
-[lib]
-crate-type = ["cdylib"]
 
 [profile.dev]
 panic = "abort"

--- a/sources/en.batcave/res/settings.json
+++ b/sources/en.batcave/res/settings.json
@@ -1,0 +1,19 @@
+[
+	{
+		"type": "group",
+		"title": "Verify Access",
+		"items": [
+			{
+				"type": "login",
+				"method": "web",
+				"url": "https://batcave.biz/",
+				"key": "verify",
+				"title": "Verify BatCave Access",
+				"logoutTitle": "Re-Verify BatCave Access",
+				"notification": "verify",
+				"refreshes": ["content"]
+			}
+		],
+		"footer": "Open this if BatCave fails to load."
+	}
+]

--- a/sources/en.batcave/res/source.json
+++ b/sources/en.batcave/res/source.json
@@ -2,12 +2,11 @@
 	"info": {
 		"id": "en.batcave",
 		"name": "BatCave",
-		"version": 1,
+		"version": 2,
 		"url": "https://batcave.biz",
 		"contentRating": 0,
-		"languages": [
-			"en"
-		]
+		"languages": ["en"],
+		"minAppVersion": "0.7.1"
 	},
 	"config": {
 		"hidesFiltersWhileSearching": true

--- a/sources/en.batcave/src/helpers.rs
+++ b/sources/en.batcave/src/helpers.rs
@@ -1,0 +1,34 @@
+use crate::{REFERER, TRUST_COOKIE_KEY, USER_AGENT, VERIFY_KEY};
+use aidoku::{
+	Result,
+	imports::{defaults::defaults_get_map, html::Document, net::Request},
+	prelude::*,
+};
+
+pub trait BatCaveHtml {
+	fn batcave_html(self) -> Result<Document>;
+}
+
+impl BatCaveHtml for Request {
+	fn batcave_html(self) -> Result<Document> {
+		let mut request = self
+			.header("Referer", REFERER)
+			.header("User-Agent", USER_AGENT);
+		if let Some(token) =
+			defaults_get_map(VERIFY_KEY).and_then(|cookies| cookies.get(TRUST_COOKIE_KEY).cloned())
+		{
+			request = request.header("Cookie", &format!("{TRUST_COOKIE_KEY}={token}"));
+		}
+		let html = request.html()?;
+
+		let is_title_empty = html
+			.select_first("title")
+			.and_then(|el| el.text())
+			.is_none_or(|s| s.is_empty());
+		if is_title_empty {
+			bail!("Verification required in settings.")
+		}
+
+		Ok(html)
+	}
+}

--- a/sources/en.batcave/src/home.rs
+++ b/sources/en.batcave/src/home.rs
@@ -1,12 +1,9 @@
-use crate::{BatCave, BASE_URL};
+use crate::{BASE_URL, BatCave, BatCaveHtml};
 use aidoku::{
-	alloc::string::ToString,
-	alloc::{Box, String, Vec},
-	imports::std::send_partial_result,
-	imports::{html::Document, net::Request, std::parse_date},
+	Home, HomeComponent, HomeLayout, HomePartialResult, Link, Manga, Result,
+	alloc::{Box, Vec, string::ToString},
+	imports::{html::Document, net::Request, std::send_partial_result},
 	prelude::*,
-	Chapter, Home, HomeComponent, HomeLayout, HomePartialResult, Link, Manga, MangaWithChapter,
-	Result,
 };
 
 type ComponentBuilderFn = Box<dyn Fn(&Document) -> Option<HomeComponent>>;
@@ -62,86 +59,45 @@ impl Home for BatCave {
 			}
 		}
 
-		fn get_home_newest_releases(html: &Document) -> Option<HomeComponent> {
-			let title = html
-				.select_first(".sect--latest > .sect__title")
-				.and_then(|x| x.text());
+		fn get_home_series_worth_starting(html: &Document) -> Option<HomeComponent> {
+			let section = html.select_first("section.sect--worth-starting")?;
+			let title = section.select_first(".sect__title").and_then(|x| x.text());
 
-			let entries = html
-				.select(".sect--latest > .sect__content > li.latest")
+			let entries = section
+				.select(".sect__content > a.grid-item")
 				.map(|elements| {
 					elements
 						.filter_map(|element| {
-							let manga_url = element
-								.select_first(".latest__title")
-								.and_then(|x| x.attr("abs:href"));
-							let manga_key = manga_url.clone()?.strip_prefix(BASE_URL)?.to_string();
-
-							let chapter_url = element
-								.select_first(".latest__chapter > a")
-								.and_then(|x| x.attr("abs:href"));
-							let chapter_key =
-								chapter_url.clone()?.strip_prefix(BASE_URL)?.to_string();
-
-							let cover = element
-								.select_first(".latest__img > img")
-								.and_then(|x| x.attr("abs:src"));
-
-							let manga_title = element
-								.select_first(".latest__title")
+							let title = element
+								.select_first(".poster__title")
 								.and_then(|x| x.text())
 								.unwrap_or_default();
+							let cover = element
+								.select_first("img")
+								.and_then(|x| x.attr("abs:data-src"));
+							let url = element.attr("abs:href");
+							let key = url.clone()?.strip_prefix(BASE_URL)?.to_string();
 
-							let details_text = element
-								.select_first(".latest__chapter")
-								.and_then(|x| x.text());
-
-							let mut date_uploaded = None;
-							let mut chapter_title = None;
-							let mut chapter_number = None;
-
-							if let Some(text) = details_text {
-								let parts = text.splitn(2, " - ").collect::<Vec<&str>>();
-								if parts.len() == 2 {
-									date_uploaded = parse_date(parts[0].trim(), "dd.MM.yyyy");
-
-									chapter_title = parts[1]
-										.strip_prefix(&manga_title)
-										.map(str::trim)
-										.map(String::from);
-
-									if let Some(idx) = parts[1].find('#') {
-										chapter_number = parts[1][idx + 1..].parse::<f32>().ok();
-									}
-								}
-							}
-
-							Some(MangaWithChapter {
-								manga: Manga {
-									key: manga_key,
-									cover,
-									title: manga_title,
-									url: manga_url,
-									..Default::default()
-								},
-								chapter: Chapter {
-									key: chapter_key,
-									url: chapter_url,
-									title: chapter_title,
-									chapter_number,
-									date_uploaded,
-									..Default::default()
-								},
+							Some(Manga {
+								key,
+								cover,
+								title,
+								url,
+								..Default::default()
 							})
 						})
-						.collect::<Vec<MangaWithChapter>>()
+						.map(Into::into)
+						.collect::<Vec<Link>>()
 				})
 				.unwrap_or_default();
 
+			if entries.is_empty() {
+				return None;
+			}
+
 			Some(HomeComponent {
 				title,
-				value: aidoku::HomeComponentValue::MangaChapterList {
-					page_size: Some(6),
+				value: aidoku::HomeComponentValue::Scroller {
 					entries,
 					listing: None,
 				},
@@ -196,13 +152,14 @@ impl Home for BatCave {
 				})
 			})
 		}
-		let html = Request::get(BASE_URL)?.html()?;
+		let html = Request::get(BASE_URL)?.batcave_html()?;
 
 		let component_fns: &[ComponentBuilderFn; 4] = &[
 			Box::new(get_home_hot_releases),
-			Box::new(get_home_newest_releases),
-			get_side_block(1),
+			Box::new(get_home_series_worth_starting),
+			// get_side_block(1), "Free Steam games"
 			get_side_block(2),
+			get_side_block(3),
 		];
 
 		for component_fn in component_fns {

--- a/sources/en.batcave/src/lib.rs
+++ b/sources/en.batcave/src/lib.rs
@@ -1,39 +1,30 @@
 #![no_std]
 use aidoku::{
-	Chapter, DeepLinkHandler, DeepLinkResult, FilterValue, ImageRequestProvider, Manga,
-	MangaPageResult, MangaStatus, Page, PageContent, Result, Source,
+	Chapter, DeepLinkHandler, DeepLinkResult, FilterValue, HashMap, ImageRequestProvider, Manga,
+	MangaPageResult, MangaStatus, Page, PageContent, Result, Source, WebLoginHandler,
 	alloc::{String, Vec, string::ToString, vec},
-	imports::{
-		net::Request,
-		std::{parse_date, send_partial_result},
-	},
+	helpers::uri::encode_uri_component,
+	imports::net::Request,
 	prelude::*,
 };
-use regex::Regex;
-use serde::Deserialize;
 
+mod helpers;
 mod home;
+mod models;
+
+use models::*;
+
+use crate::helpers::BatCaveHtml;
 
 const BASE_URL: &str = "https://batcave.biz";
 const REFERER: &str = "https://batcave.biz/";
+const USER_AGENT: &str = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) \
+                          AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.5 \
+                          Mobile/15E148 Safari/604.1";
+const VERIFY_KEY: &str = "verify";
+const TRUST_COOKIE_KEY: &str = "__guard_trust";
 
 struct BatCave;
-
-#[derive(Deserialize)]
-struct ChapterList {
-	news_id: i32,
-	chapters: Vec<SingleChapter>,
-}
-#[derive(Deserialize)]
-struct SingleChapter {
-	date: String,
-	id: i32,
-	title: String,
-}
-#[derive(Deserialize)]
-struct PageList {
-	images: Vec<String>,
-}
 
 impl Source for BatCave {
 	fn new() -> Self {
@@ -46,12 +37,16 @@ impl Source for BatCave {
 		page: i32,
 		filters: Vec<FilterValue>,
 	) -> Result<MangaPageResult> {
-		let mut filters_vec = Vec::<String>::new();
-
-		for filter in filters {
-			match filter {
-				FilterValue::Range { id, from, to } => {
-					if id.as_str() == "year_of_issue" {
+		let url = if let Some(query) = query {
+			format!(
+				"{BASE_URL}/search/{}/page/{page}/",
+				encode_uri_component(query)
+			)
+		} else {
+			let mut filters_vec = Vec::<String>::new();
+			for filter in filters {
+				match filter {
+					FilterValue::Range { from, to, .. } => {
 						if let Some(from) = from {
 							filters_vec.push(format!("y[from]={}", from));
 						}
@@ -59,48 +54,46 @@ impl Source for BatCave {
 							filters_vec.push(format!("y[to]={}", to));
 						}
 					}
-				}
-				FilterValue::MultiSelect { id, included, .. } => {
-					if id.as_str() == "genre" {
+					FilterValue::MultiSelect { included, .. } => {
 						filters_vec.push(format!("g={}", included.join(",")));
 					}
+					_ => {}
 				}
-				_ => {}
 			}
-		}
-
-		let url = if filters_vec.is_empty() {
-			format!(
-				"{BASE_URL}/search/{}/page/{page}/",
-				query.unwrap_or_default()
-			)
-		} else {
-			format!(
-				"{BASE_URL}/ComicList/{}/page/{page}/",
-				filters_vec.join("/")
-			)
+			if !filters_vec.is_empty() {
+				format!(
+					"{BASE_URL}/ComicList/{}/page/{page}/",
+					filters_vec.join("/")
+				)
+			} else {
+				format!(
+					"{BASE_URL}/comix/{}",
+					if page > 1 {
+						format!("page/{page}/")
+					} else {
+						String::new()
+					}
+				)
+			}
 		};
 
-		let result = Request::get(&url)?.html()?;
+		let html = Request::get(&url)?.batcave_html()?;
 
-		let entries = result
-			.select("#dle-content > div:not(.pagination)")
+		let entries = html
+			.select("#dle-content > .readed")
 			.map(|elements| {
 				elements
 					.filter_map(|element| {
-						let url = element.select_first("a")?.attr("abs:href");
-						let key = url.clone()?.strip_prefix(BASE_URL)?.to_string();
+						let link = element.select_first(".readed__title > a")?;
+						let url = link.attr("abs:href")?;
+						let key = url.strip_prefix(BASE_URL)?.to_string();
 						let cover = element.select_first("img")?.attr("abs:data-src");
-						let title = element
-							.select_first("div > h2")
-							.and_then(|x| x.text())
-							.unwrap_or_default();
-
+						let title = link.own_text()?;
 						Some(Manga {
 							key,
 							cover,
 							title,
-							url,
+							url: Some(url),
 							..Default::default()
 						})
 					})
@@ -108,7 +101,11 @@ impl Source for BatCave {
 			})
 			.unwrap_or_default();
 
-		let has_next_page = !entries.is_empty();
+		let has_next_page = html
+			.select_first("div.pagination__pages")
+			.and_then(|el| el.children().next_back())
+			.map(|child| child.tag_name().as_deref() == Some("a"))
+			.unwrap_or_default();
 
 		Ok(MangaPageResult {
 			entries,
@@ -123,7 +120,7 @@ impl Source for BatCave {
 		needs_chapters: bool,
 	) -> Result<Manga> {
 		let url = format!("{BASE_URL}{}", manga.key);
-		let html = Request::get(&url)?.html()?;
+		let html = Request::get(&url)?.batcave_html()?;
 
 		if needs_details {
 			manga.title = html
@@ -168,10 +165,6 @@ impl Source for BatCave {
 				"Ongoing" => MangaStatus::Ongoing,
 				_ => MangaStatus::Unknown,
 			};
-
-			if needs_chapters {
-				send_partial_result(&manga);
-			}
 		}
 
 		if needs_chapters {
@@ -190,31 +183,7 @@ impl Source for BatCave {
 			let chapters = chapter_list
 				.chapters
 				.into_iter()
-				.map(|chapter| {
-					let url = format!("/reader/{}/{}", chapter_list.news_id, chapter.id);
-
-					let title = chapter
-						.title
-						.strip_prefix(&manga.title)
-						.map(str::trim)
-						.map(String::from)
-						.unwrap_or_else(|| chapter.title);
-
-					let chapter_number = title
-						.find('#')
-						.and_then(|idx| title[idx + 1..].parse::<f32>().ok());
-
-					let date_uploaded = parse_date(&chapter.date, "dd.MM.yyyy");
-
-					Chapter {
-						key: url.clone(),
-						url: Some(url),
-						title: Some(title),
-						chapter_number,
-						date_uploaded,
-						..Default::default()
-					}
-				})
+				.map(|chapter| chapter.into_chapter(chapter_list.news_id, &manga.title))
 				.collect::<Vec<Chapter>>();
 
 			manga.chapters = Some(chapters);
@@ -225,7 +194,7 @@ impl Source for BatCave {
 
 	fn get_page_list(&self, _manga: Manga, chapter: Chapter) -> Result<Vec<Page>> {
 		let url = format!("{BASE_URL}{}", chapter.key);
-		let html = Request::get(&url)?.html()?;
+		let html = Request::get(&url)?.batcave_html()?;
 
 		let pages = html
 			.select("script")
@@ -237,23 +206,22 @@ impl Source for BatCave {
 							return None;
 						}
 
-						let page_json_str = text
-							.strip_prefix("window.__DATA__ = ")
-							.and_then(|x| x.strip_suffix(";"))
-							.unwrap_or_default();
+						let page_json_str =
+							text.strip_prefix("window.__DATA__ = ")?.strip_suffix(";")?;
 
 						let page_list = serde_json::from_str::<PageList>(page_json_str).ok()?;
 
 						let pages = page_list
 							.images
 							.into_iter()
-							.map(|mut page_url| {
-								if page_url.starts_with("/") {
-									page_url = format!("{BASE_URL}{}", page_url);
-								}
-
+							.map(|page_url| {
+								let url = if page_url.starts_with("/") {
+									format!("{BASE_URL}{}", page_url)
+								} else {
+									page_url
+								};
 								Page {
-									content: PageContent::url(page_url),
+									content: PageContent::url(url),
 									..Default::default()
 								}
 							})
@@ -267,6 +235,12 @@ impl Source for BatCave {
 			.unwrap_or_default();
 
 		Ok(pages)
+	}
+}
+
+impl WebLoginHandler for BatCave {
+	fn handle_web_login(&self, key: String, cookies: HashMap<String, String>) -> Result<bool> {
+		Ok(key == VERIFY_KEY && cookies.contains_key(TRUST_COOKIE_KEY))
 	}
 }
 
@@ -286,25 +260,36 @@ impl ImageRequestProvider for BatCave {
 
 impl DeepLinkHandler for BatCave {
 	fn handle_deep_link(&self, url: String) -> Result<Option<DeepLinkResult>> {
-		let pattern = format!(r"^{}\/\d+-[\w-]+\.html$", regex::escape(BASE_URL));
+		let Some(key) = url.strip_prefix(BASE_URL) else {
+			return Ok(None);
+		};
+		let Some((id, slug)) = key.strip_prefix('/').and_then(|path| path.split_once('-')) else {
+			return Ok(None);
+		};
+		let Some(slug) = slug.strip_suffix(".html") else {
+			return Ok(None);
+		};
 
-		let re = Regex::new(&pattern);
-		if re.is_err() {
+		if id.is_empty()
+			|| slug.is_empty()
+			|| !id.bytes().all(|byte| byte.is_ascii_digit())
+			|| !slug
+				.bytes()
+				.all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+		{
 			return Ok(None);
 		}
 
-		let re = re.unwrap();
-		if !re.is_match(&url) {
-			return Ok(None);
-		}
-
-		let key = url
-			.strip_prefix(BASE_URL)
-			.ok_or(error!("Invalid URL prefix"))?
-			.to_string();
-
-		Ok(Some(DeepLinkResult::Manga { key }))
+		Ok(Some(DeepLinkResult::Manga {
+			key: key.to_string(),
+		}))
 	}
 }
 
-register_source!(BatCave, Home, ImageRequestProvider, DeepLinkHandler);
+register_source!(
+	BatCave,
+	Home,
+	ImageRequestProvider,
+	DeepLinkHandler,
+	WebLoginHandler
+);

--- a/sources/en.batcave/src/models.rs
+++ b/sources/en.batcave/src/models.rs
@@ -1,0 +1,51 @@
+use aidoku::{
+	Chapter,
+	alloc::{string::String, vec::Vec},
+	imports::std::parse_date,
+	prelude::*,
+};
+use serde::Deserialize;
+
+use crate::BASE_URL;
+
+#[derive(Deserialize)]
+pub struct ChapterList {
+	pub news_id: i32,
+	pub chapters: Vec<SingleChapter>,
+}
+
+#[derive(Deserialize)]
+pub struct SingleChapter {
+	date: String,
+	id: i32,
+	title: String,
+}
+
+impl SingleChapter {
+	pub fn into_chapter(self, news_id: i32, manga_title: &str) -> Chapter {
+		let key = format!("/reader/{}/{}", news_id, self.id);
+		let title = self
+			.title
+			.strip_prefix(manga_title)
+			.map(|s| s.trim().into())
+			.unwrap_or_else(|| self.title);
+		let chapter_number = title
+			.find('#')
+			.and_then(|idx| title[idx + 1..].parse::<f32>().ok());
+		let date_uploaded = parse_date(&self.date, "dd.MM.yyyy");
+		let url = format!("{BASE_URL}{key}");
+		Chapter {
+			key,
+			title: Some(title),
+			chapter_number,
+			date_uploaded,
+			url: Some(url),
+			..Default::default()
+		}
+	}
+}
+
+#[derive(Deserialize)]
+pub struct PageList {
+	pub images: Vec<String>,
+}


### PR DESCRIPTION
closes #552.

adds a verify button in settings like the comix source that can get the necessary cookies. if support is added to aidoku-rs to obtain cookies, this could maybe be avoided in the future.