### PR TITLE
fix(ja.mangarawbest): update content rating

### DIFF
--- a/sources/ja.mangarawbest/res/source.json
+++ b/sources/ja.mangarawbest/res/source.json
@@ -2,9 +2,9 @@
 	"info": {
 		"id": "ja.mangarawbest",
 		"name": "Manga Raw Best",
-		"version": 1,
+		"version": 2,
 		"url": "https://mangaraw.best",
-		"contentRating": 1,
+		"contentRating": 2,
 		"languages": [
 			"ja"
 		]


### PR DESCRIPTION
## Summary

* Updated `contentRating` from 1 (mature) to 2 (adult). The site contains adult content as a primary focus rather than an incidental element, with permanent categories such as "Adult" and "Ecchi" listed in the genres.
* Updated `version` from 1 to 2 (for metadata update).


## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy --release`
- [x] `cargo test --release` (19 passed)
- [x] `aidoku package && aidoku verify package.aix`