### PR TITLE
fix(ja.mangamura): update url

### DIFF
--- a/sources/ja.mangamura/res/source.json
+++ b/sources/ja.mangamura/res/source.json
@@ -2,8 +2,8 @@
 	"info": {
 		"id": "ja.mangamura",
 		"name": "Manga Mura",
-		"version": 1,
-		"url": "https://mangamura.net",
+		"version": 2,
+		"url": "https://mangamura.me",
 		"contentRating": 1,
 		"languages": ["ja"]
 	},

--- a/sources/ja.mangamura/src/lib.rs
+++ b/sources/ja.mangamura/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
-use aidoku::{alloc::borrow::Cow, prelude::*, Source};
+use aidoku::{Source, alloc::borrow::Cow, prelude::*};
 use mangareader::{Impl, MangaReader, Params};
 
-const BASE_URL: &str = "https://mangamura.net";
+const BASE_URL: &str = "https://mangamura.me";
 
 struct MangaMura;
 
@@ -50,3 +50,49 @@ register_source!(
 	ImageRequestProvider,
 	DeepLinkHandler
 );
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use aidoku::alloc::{String, vec::Vec};
+	use aidoku_test::aidoku_test;
+
+	fn source() -> MangaReader<MangaMura> {
+		Source::new()
+	}
+
+	// The site links entries with absolute urls, so keys are only stripped down
+	// to paths when BASE_URL matches the live domain. A stale domain silently
+	// turns every key into a full url and breaks details and chapter lists.
+	#[aidoku_test]
+	fn search_returns_path_keys() {
+		let result = source()
+			.get_search_manga_list(Some(String::from("ワンピース")), 1, Vec::new())
+			.expect("search failed");
+		assert!(!result.entries.is_empty(), "expected at least one result");
+		for manga in &result.entries {
+			assert!(
+				manga.key.starts_with('/'),
+				"expected a path key, got {}",
+				manga.key
+			);
+		}
+	}
+
+	#[aidoku_test]
+	fn manga_details_have_chapters() {
+		let source = source();
+		let manga = source
+			.get_search_manga_list(Some(String::from("ワンピース")), 1, Vec::new())
+			.expect("search failed")
+			.entries
+			.into_iter()
+			.next()
+			.expect("expected at least one result");
+		let manga = source
+			.get_manga_update(manga, true, true)
+			.expect("get_manga_update failed");
+		let chapters = manga.chapters.expect("no chapters returned");
+		assert!(chapters.len() > 100, "got {} chapters", chapters.len());
+	}
+}


### PR DESCRIPTION
Mangamura moved from `mangamura.net` to `mangamura.me`. The old domain
redirects to the new one, so the source still loads pages — but every key
it produces is wrong, and nothing surfaces as an error in the app.

`mangareader` builds `Manga.key` / `Chapter.key` by stripping `BASE_URL`
from the absolute `href` the site emits. With a stale `BASE_URL` the prefix
never matches, so keys stay full URLs: details fail to resolve and the
chapter list drops every entry.

Changes:

- `BASE_URL` and the `url` in `res/source.json` → `https://mangamura.me`
- `version` 1 → 2

Search, listing, details and page fetching were all re-checked against the
new domain. The key format is unchanged once `BASE_URL` matches the live
domain again, so no `breakingChangeVersion` is needed.

Also added two regression tests for the failure above: one asserts search
results carry path keys rather than absolute URLs, the other asserts a
title resolves into a non-empty chapter list.