### PR TITLE
fix(vi.cuutruyen): images not showing

### DIFF
--- a/sources/vi.cuutruyen/res/filters.json
+++ b/sources/vi.cuutruyen/res/filters.json
@@ -72,8 +72,6 @@
 			"Monsters",
 			"Mystery",
 			"Ninja",
-			"Nsfw",
-			"Ntr",
 			"Oneshot",
 			"Philosophical",
 			"Police",

--- a/sources/vi.cuutruyen/res/source.json
+++ b/sources/vi.cuutruyen/res/source.json
@@ -2,12 +2,10 @@
 	"info": {
 		"id": "vi.cuutruyen",
 		"name": "Cứu Truyện",
-		"version": 4,
+		"version": 5,
 		"urls": [
 			"https://cuutruyen.net",
-			"https://hetcuutruyen.net",
-			"https://nettrom.com",
-			"https://cuutruyen5c844.site"
+			"https://hetcuutruyen.net"
 		],
 		"contentRating": 1,
 		"minAppVersion": "0.7.1",

--- a/sources/vi.cuutruyen/src/helpers.rs
+++ b/sources/vi.cuutruyen/src/helpers.rs
@@ -1,0 +1,14 @@
+use aidoku::alloc::string::{String, ToString};
+
+const REPLACEMENTS: &[(&str, &str)] = &[
+	("storage-ct.lrclib.net", "storage-bravo.cuutruyen.net"),
+	("storage-ct-riften.site", "storage-charlie.cuutruyen.net"),
+];
+
+pub fn rewrite_storage_url(url: impl AsRef<str>) -> String {
+	let mut result = url.as_ref().to_string();
+	for &(old_host, new_host) in REPLACEMENTS {
+		result = result.replace(old_host, new_host);
+	}
+	result
+}

--- a/sources/vi.cuutruyen/src/home.rs
+++ b/sources/vi.cuutruyen/src/home.rs
@@ -1,15 +1,15 @@
 // a source made by @c0ntens
-use crate::models::*;
 use crate::CuuTruyen;
+use crate::{helpers::rewrite_storage_url, models::*};
 use aidoku::{
-	alloc::{string::ToString, vec, String, Vec},
+	BaseUrlProvider, Chapter, Home, HomeComponent, HomeLayout, HomePartialResult, Link, Listing,
+	ListingKind, Manga, MangaWithChapter, Result,
+	alloc::{String, Vec, string::ToString, vec},
 	imports::{
 		net::{Request, RequestError, Response},
 		std::send_partial_result,
 	},
 	prelude::*,
-	BaseUrlProvider, Chapter, Home, HomeComponent, HomeLayout, HomePartialResult, Link, Listing,
-	ListingKind, Manga, MangaWithChapter, Result,
 };
 
 impl Home for CuuTruyen {
@@ -80,7 +80,7 @@ impl Home for CuuTruyen {
 				Some(
 					res.ok()?
 						.get_json::<CuuSearchResponse<CuuMangaDetails>>()
-						.unwrap()
+						.ok()?
 						.data
 						.into(),
 				)
@@ -119,7 +119,7 @@ impl Home for CuuTruyen {
 					manga: Manga {
 						key: value.id.to_string(),
 						title: value.name.to_string(),
-						cover: value.cover_url.clone(),
+						cover: value.cover_url.as_ref().map(rewrite_storage_url),
 						..Default::default()
 					},
 					chapter: Chapter {

--- a/sources/vi.cuutruyen/src/lib.rs
+++ b/sources/vi.cuutruyen/src/lib.rs
@@ -16,10 +16,12 @@ use aidoku::{
 	prelude::*,
 };
 
+mod helpers;
 mod home;
 mod models;
 
 use base64::{Engine, engine::general_purpose};
+use helpers::rewrite_storage_url;
 use models::*;
 
 struct CuuTruyen;
@@ -138,15 +140,11 @@ impl Source for CuuTruyen {
 					let title = if chapter_number.is_none()
 						&& !chap.name.as_ref().is_none_or(|r| r.is_empty())
 					{
-						Some(format!(
-							"Ch.{} - {}",
-							chap.number.clone(),
-							chap.name.unwrap().clone()
-						))
+						Some(format!("Ch.{} - {}", chap.number, chap.name.unwrap()))
 					} else if chapter_number.is_none()
 						&& chap.name.as_ref().is_none_or(|r| r.is_empty())
 					{
-						Some(format!("Ch.{}", chap.number.clone()))
+						Some(format!("Ch.{}", chap.number))
 					} else {
 						chap.name.clone()
 					};
@@ -191,7 +189,7 @@ impl Source for CuuTruyen {
 				);
 
 				Page {
-					content: PageContent::url_context(p.image_url, context),
+					content: PageContent::url_context(rewrite_storage_url(p.image_url), context),
 					..Default::default()
 				}
 			})
@@ -227,7 +225,7 @@ impl PageImageProcessor for CuuTruyen {
 			.unwrap_or_default();
 
 		// if the image is not from the specified CDN, return the original image without trying to descramble
-		if response.request.url.is_none() || drm_data.is_empty() {
+		if response.request.url.is_none() || drm_data.is_empty() || response.code >= 400 {
 			return Ok(response.image);
 		};
 
@@ -310,8 +308,6 @@ impl DeepLinkHandler for CuuTruyen {
 		let all_urls = vec![
 			"https://cuutruyen.net",
 			"https://hetcuutruyen.net",
-			"https://nettrom.com",
-			"https://cuutruyen5c844.site",
 			"https://truycapcuutruyen.pages.dev",
 		];
 

--- a/sources/vi.cuutruyen/src/models.rs
+++ b/sources/vi.cuutruyen/src/models.rs
@@ -1,10 +1,11 @@
 // a source made by @c0ntens
+use crate::helpers::rewrite_storage_url;
 use aidoku::{
-	alloc::{string::ToString, vec, String, Vec},
+	ContentRating, Manga, MangaStatus, Viewer,
+	alloc::{String, Vec, string::ToString, vec},
 	helpers::element::ElementHelpers,
 	imports::html::Html,
 	prelude::format,
-	ContentRating, Manga, MangaStatus, Viewer,
 };
 use serde::Deserialize;
 
@@ -95,7 +96,7 @@ impl CuuManga {
 		Manga {
 			key: self.id.to_string(),
 			title: self.name.to_string(),
-			cover: self.cover_url.clone(),
+			cover: self.cover_url.as_ref().map(rewrite_storage_url),
 			..Default::default()
 		}
 	}
@@ -164,13 +165,7 @@ impl From<CuuMangaDetails> for Manga {
 			MangaStatus::Unknown
 		};
 
-		let content_rating = if val.is_nsfw
-			|| tags
-				.iter()
-				.any(|tag| tag == "Khỏa Thân" || tag == "Nsfw" || tag == "Ntr")
-		{
-			ContentRating::NSFW
-		} else if tags.iter().any(|tag| tag == "Ecchi") {
+		let content_rating = if tags.iter().any(|tag| tag == "Ecchi") {
 			ContentRating::Suggestive
 		} else {
 			ContentRating::Safe
@@ -191,7 +186,7 @@ impl From<CuuMangaDetails> for Manga {
 		Manga {
 			key: val.id.to_string(),
 			title: val.name.to_string(),
-			cover: val.cover_url.clone(),
+			cover: val.cover_url.as_ref().map(rewrite_storage_url),
 			authors: val.authors(),
 			description: val.description(),
 			url: Some(format!(


### PR DESCRIPTION
Problem: The API servers doesn't change cdn storage host for manga cover and page image it

I tested it and worked
- [x] `cargo fmt`
- [x] `cargo clippy`
- [x] `aidoku package`