### PR TITLE
feat(en.mangakakalot): add base url selection

### DIFF
--- a/sources/en.mangakakalot/res/source.json
+++ b/sources/en.mangakakalot/res/source.json
@@ -2,13 +2,14 @@
 	"info": {
 		"id": "en.mangakakalot",
 		"name": "MangaKakalot",
-		"version": 4,
+		"version": 5,
 		"urls": [
 			"https://www.mangakakalot.gg",
 			"https://www.mangakakalove.com"
 		],
 		"contentRating": 1,
-		"languages": ["en"]
+		"languages": ["en"],
+		"minAppVersion": "0.7.1"
 	},
 	"listings": [
 		{
@@ -29,6 +30,7 @@
 		}
 	],
 	"config": {
+		"allowsBaseUrlSelect": true,
 		"supportsAuthorSearch": true,
 		"supportsTagSearch": true,
 		"hidesFiltersWhileSearching": true

--- a/sources/en.mangakakalot/res/source.json
+++ b/sources/en.mangakakalot/res/source.json
@@ -1,35 +1,38 @@
 {
-  "info": {
-    "id": "en.mangakakalot",
-    "name": "MangaKakalot",
-    "version": 5,
-    "urls": ["https://www.mangakakalot.gg", "https://www.mangakakalove.com"],
-    "contentRating": 1,
-    "languages": ["en"],
-    "minAppVersion": "0.7.1"
-  },
-  "listings": [
-    {
-      "id": "latest",
-      "name": "Latest Manga"
-    },
-    {
-      "id": "hot",
-      "name": "Hot Manga"
-    },
-    {
-      "id": "new",
-      "name": "New Manga"
-    },
-    {
-      "id": "completed",
-      "name": "Completed Manga"
-    }
-  ],
-  "config": {
-    "allowsBaseUrlSelect": true,
-    "supportsAuthorSearch": true,
-    "supportsTagSearch": true,
-    "hidesFiltersWhileSearching": true
-  }
+	"info": {
+		"id": "en.mangakakalot",
+		"name": "MangaKakalot",
+		"version": 5,
+		"urls": [
+			"https://www.mangakakalot.gg",
+			"https://www.mangakakalove.com"
+		],
+		"contentRating": 1,
+		"languages": ["en"],
+		"minAppVersion": "0.7.1"
+	},
+	"listings": [
+		{
+			"id": "latest",
+			"name": "Latest Manga"
+		},
+		{
+			"id": "hot",
+			"name": "Hot Manga"
+		},
+		{
+			"id": "new",
+			"name": "New Manga"
+		},
+		{
+			"id": "completed",
+			"name": "Completed Manga"
+		}
+	],
+	"config": {
+		"allowsBaseUrlSelect": true,
+		"supportsAuthorSearch": true,
+		"supportsTagSearch": true,
+		"hidesFiltersWhileSearching": true
+	}
 }

--- a/sources/en.mangakakalot/res/source.json
+++ b/sources/en.mangakakalot/res/source.json
@@ -1,38 +1,35 @@
 {
-	"info": {
-		"id": "en.mangakakalot",
-		"name": "MangaKakalot",
-		"version": 5,
-		"urls": [
-			"https://www.mangakakalot.gg",
-			"https://www.mangakakalove.com"
-		],
-		"contentRating": 1,
-		"languages": ["en"],
-		"minAppVersion": "0.7.1"
-	},
-	"listings": [
-		{
-			"id": "latest",
-			"name": "Latest Manga"
-		},
-		{
-			"id": "hot",
-			"name": "Hot Manga"
-		},
-		{
-			"id": "new",
-			"name": "New Manga"
-		},
-		{
-			"id": "completed",
-			"name": "Completed Manga"
-		}
-	],
-	"config": {
-		"allowsBaseUrlSelect": true,
-		"supportsAuthorSearch": true,
-		"supportsTagSearch": true,
-		"hidesFiltersWhileSearching": true
-	}
+  "info": {
+    "id": "en.mangakakalot",
+    "name": "MangaKakalot",
+    "version": 5,
+    "urls": ["https://www.mangakakalot.gg", "https://www.mangakakalove.com"],
+    "contentRating": 1,
+    "languages": ["en"],
+    "minAppVersion": "0.7.1"
+  },
+  "listings": [
+    {
+      "id": "latest",
+      "name": "Latest Manga"
+    },
+    {
+      "id": "hot",
+      "name": "Hot Manga"
+    },
+    {
+      "id": "new",
+      "name": "New Manga"
+    },
+    {
+      "id": "completed",
+      "name": "Completed Manga"
+    }
+  ],
+  "config": {
+    "allowsBaseUrlSelect": true,
+    "supportsAuthorSearch": true,
+    "supportsTagSearch": true,
+    "hidesFiltersWhileSearching": true
+  }
 }

--- a/sources/en.mangakakalot/src/lib.rs
+++ b/sources/en.mangakakalot/src/lib.rs
@@ -11,8 +11,6 @@ impl Impl for MangaKakalot {
 		Self
 	}
 
-	// this only runs when the source is created, which is why the base url setting refreshes
-	// content: changing it has the app build a new source
 	fn params(&self) -> Params {
 		let base_url = defaults_get::<String>("url").unwrap_or_else(|| BASE_URL.into());
 		Params {

--- a/sources/en.mangakakalot/src/lib.rs
+++ b/sources/en.mangakakalot/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use aidoku::{prelude::*, Source};
+use aidoku::{Source, alloc::String, imports::defaults::defaults_get, prelude::*};
 use mangabox::{Impl, MangaBox, Params};
 
 const BASE_URL: &str = "https://www.mangakakalot.gg";
@@ -12,8 +12,11 @@ impl Impl for MangaKakalot {
 	}
 
 	fn params(&self) -> Params {
+		let base_url = defaults_get::<String>("url")
+			.filter(|url| !url.is_empty())
+			.unwrap_or_else(|| BASE_URL.into());
 		Params {
-			base_url: BASE_URL.into(),
+			base_url: base_url.into(),
 			..Default::default()
 		}
 	}
@@ -26,3 +29,6 @@ register_source!(
 	ImageRequestProvider,
 	DeepLinkHandler
 );
+
+#[cfg(test)]
+mod test;

--- a/sources/en.mangakakalot/src/lib.rs
+++ b/sources/en.mangakakalot/src/lib.rs
@@ -11,10 +11,10 @@ impl Impl for MangaKakalot {
 		Self
 	}
 
+	// this only runs when the source is created, which is why the base url setting refreshes
+	// content: changing it has the app build a new source
 	fn params(&self) -> Params {
-		let base_url = defaults_get::<String>("url")
-			.filter(|url| !url.is_empty())
-			.unwrap_or_else(|| BASE_URL.into());
+		let base_url = defaults_get::<String>("url").unwrap_or_else(|| BASE_URL.into());
 		Params {
 			base_url: base_url.into(),
 			..Default::default()

--- a/sources/en.mangakakalot/src/test.rs
+++ b/sources/en.mangakakalot/src/test.rs
@@ -11,41 +11,16 @@ use aidoku::{
 };
 use aidoku_test::aidoku_test;
 
-<<<<<<< HEAD
-/// "Solo Leveling", a completed webtoon with a few hundred chapters, used to check parsing
-/// against.
-const MANGA_KEY: &str = "/manga/solo-leveling";
-
-/// The mirror listed second in `source.json`, reachable while the default url answers every
-/// content path with a cloudflare challenge.
-const MIRROR_URL: &str = "https://www.mangakakalove.com";
-
-/// Selecting a base url is the whole point of the change, so the tests run against the value the
-/// setting writes rather than the compiled in fallback. The test runner starts with no stored
-/// defaults, so this stands in for the dropdown.
-fn source() -> MangaBox<MangaKakalot> {
-	pause();
-=======
 const MANGA_KEY: &str = "/manga/solo-leveling";
 
 const MIRROR_URL: &str = "https://www.mangakakalove.com";
 
 fn source() -> MangaBox<MangaKakalot> {
 	sleep(3);
->>>>>>> 3ae3c93 (fix(en.mangakakalot): add minApiVersion, cleanup, add tests)
 	defaults_set("url", DefaultValue::String(MIRROR_URL.into()));
 	Source::new()
 }
 
-<<<<<<< HEAD
-/// The site answers back to back requests with 429, and the test runner does not rate limit. Run
-/// with `--test-threads=1` so these actually space the requests out.
-fn pause() {
-	sleep(3);
-}
-
-=======
->>>>>>> 3ae3c93 (fix(en.mangakakalot): add minApiVersion, cleanup, add tests)
 fn listing(id: &str) -> Listing {
 	Listing {
 		id: id.into(),
@@ -116,11 +91,7 @@ fn listings_test() {
 		let result = with_retry(|| source.get_manga_list(listing(id), 1));
 
 		assert_entries(&result);
-<<<<<<< HEAD
-		pause();
-=======
 		sleep(3);
->>>>>>> 3ae3c93 (fix(en.mangakakalot): add minApiVersion, cleanup, add tests)
 	}
 }
 
@@ -155,12 +126,6 @@ fn manga_details_test() {
 			.as_deref()
 			.is_some_and(|url| url.ends_with(MANGA_KEY))
 	);
-<<<<<<< HEAD
-	// authors, tags, status and viewer are read with `:contains`/`:containsOwn`, jsoup
-	// extensions the test runner's css engine cannot parse, so they only fill in inside the
-	// app and have to be checked there
-=======
->>>>>>> 3ae3c93 (fix(en.mangakakalot): add minApiVersion, cleanup, add tests)
 
 	let chapters = manga.chapters.expect("no chapters");
 	// the chapter api pages 500 at a time, so this also covers a series past a single page
@@ -196,11 +161,7 @@ fn page_list_test() {
 		.take()
 		.and_then(|chapters| chapters.into_iter().next())
 		.expect("no chapters");
-<<<<<<< HEAD
-	pause();
-=======
 	sleep(3);
->>>>>>> 3ae3c93 (fix(en.mangakakalot): add minApiVersion, cleanup, add tests)
 
 	let pages = source
 		.get_page_list(manga, chapter)

--- a/sources/en.mangakakalot/src/test.rs
+++ b/sources/en.mangakakalot/src/test.rs
@@ -11,6 +11,7 @@ use aidoku::{
 };
 use aidoku_test::aidoku_test;
 
+<<<<<<< HEAD
 /// "Solo Leveling", a completed webtoon with a few hundred chapters, used to check parsing
 /// against.
 const MANGA_KEY: &str = "/manga/solo-leveling";
@@ -24,16 +25,27 @@ const MIRROR_URL: &str = "https://www.mangakakalove.com";
 /// defaults, so this stands in for the dropdown.
 fn source() -> MangaBox<MangaKakalot> {
 	pause();
+=======
+const MANGA_KEY: &str = "/manga/solo-leveling";
+
+const MIRROR_URL: &str = "https://www.mangakakalove.com";
+
+fn source() -> MangaBox<MangaKakalot> {
+	sleep(3);
+>>>>>>> 3ae3c93 (fix(en.mangakakalot): add minApiVersion, cleanup, add tests)
 	defaults_set("url", DefaultValue::String(MIRROR_URL.into()));
 	Source::new()
 }
 
+<<<<<<< HEAD
 /// The site answers back to back requests with 429, and the test runner does not rate limit. Run
 /// with `--test-threads=1` so these actually space the requests out.
 fn pause() {
 	sleep(3);
 }
 
+=======
+>>>>>>> 3ae3c93 (fix(en.mangakakalot): add minApiVersion, cleanup, add tests)
 fn listing(id: &str) -> Listing {
 	Listing {
 		id: id.into(),
@@ -104,7 +116,11 @@ fn listings_test() {
 		let result = with_retry(|| source.get_manga_list(listing(id), 1));
 
 		assert_entries(&result);
+<<<<<<< HEAD
 		pause();
+=======
+		sleep(3);
+>>>>>>> 3ae3c93 (fix(en.mangakakalot): add minApiVersion, cleanup, add tests)
 	}
 }
 
@@ -139,9 +155,12 @@ fn manga_details_test() {
 			.as_deref()
 			.is_some_and(|url| url.ends_with(MANGA_KEY))
 	);
+<<<<<<< HEAD
 	// authors, tags, status and viewer are read with `:contains`/`:containsOwn`, jsoup
 	// extensions the test runner's css engine cannot parse, so they only fill in inside the
 	// app and have to be checked there
+=======
+>>>>>>> 3ae3c93 (fix(en.mangakakalot): add minApiVersion, cleanup, add tests)
 
 	let chapters = manga.chapters.expect("no chapters");
 	// the chapter api pages 500 at a time, so this also covers a series past a single page
@@ -177,7 +196,11 @@ fn page_list_test() {
 		.take()
 		.and_then(|chapters| chapters.into_iter().next())
 		.expect("no chapters");
+<<<<<<< HEAD
 	pause();
+=======
+	sleep(3);
+>>>>>>> 3ae3c93 (fix(en.mangakakalot): add minApiVersion, cleanup, add tests)
 
 	let pages = source
 		.get_page_list(manga, chapter)

--- a/sources/en.mangakakalot/src/test.rs
+++ b/sources/en.mangakakalot/src/test.rs
@@ -1,0 +1,193 @@
+#![expect(clippy::unwrap_used, clippy::panic)]
+
+use super::*;
+use aidoku::{
+	Listing, ListingProvider, Manga, MangaPageResult, PageContent, Result,
+	alloc::vec,
+	imports::{
+		defaults::{DefaultValue, defaults_set},
+		std::sleep,
+	},
+};
+use aidoku_test::aidoku_test;
+
+/// "Solo Leveling", a completed webtoon with a few hundred chapters, used to check parsing
+/// against.
+const MANGA_KEY: &str = "/manga/solo-leveling";
+
+/// The mirror listed second in `source.json`, reachable while the default url answers every
+/// content path with a cloudflare challenge.
+const MIRROR_URL: &str = "https://www.mangakakalove.com";
+
+/// Selecting a base url is the whole point of the change, so the tests run against the value the
+/// setting writes rather than the compiled in fallback. The test runner starts with no stored
+/// defaults, so this stands in for the dropdown.
+fn source() -> MangaBox<MangaKakalot> {
+	pause();
+	defaults_set("url", DefaultValue::String(MIRROR_URL.into()));
+	Source::new()
+}
+
+/// The site answers back to back requests with 429, and the test runner does not rate limit. Run
+/// with `--test-threads=1` so these actually space the requests out.
+fn pause() {
+	sleep(3);
+}
+
+fn listing(id: &str) -> Listing {
+	Listing {
+		id: id.into(),
+		..Default::default()
+	}
+}
+
+/// A 429 comes back as a page that parses into no entries at all, so give a request a couple of
+/// extra tries before calling it a failure.
+fn with_retry(mut fetch: impl FnMut() -> Result<MangaPageResult>) -> MangaPageResult {
+	for attempt in 1..=3 {
+		let result = fetch().expect("request failed");
+		if !result.entries.is_empty() {
+			return result;
+		}
+		assert!(attempt < 3, "no entries after {attempt} attempts");
+		sleep(10);
+	}
+	unreachable!()
+}
+
+fn assert_entries(result: &MangaPageResult) {
+	// the catalog spans thousands of pages, so the first one is never last
+	assert!(result.has_next_page);
+
+	let mut count = 0;
+	for manga in &result.entries {
+		// each page carries one hidden ad placeholder that matches the item selector and
+		// comes through as an empty entry
+		if manga.key == "#" {
+			continue;
+		}
+		count += 1;
+
+		assert!(
+			manga.key.starts_with("/manga/"),
+			"unexpected key {:?} (title {:?})",
+			manga.key,
+			manga.title
+		);
+		assert!(!manga.title.is_empty());
+		assert!(
+			manga
+				.cover
+				.as_deref()
+				.is_some_and(|cover| cover.starts_with("https://"))
+		);
+	}
+
+	assert!(count >= 10, "only {count} entries");
+}
+
+#[aidoku_test]
+fn browse_test() {
+	let source = source();
+	let result = with_retry(|| source.get_search_manga_list(None, 1, vec![]));
+
+	assert_entries(&result);
+}
+
+/// The listings are what broke: every one of them goes through `/genre/all?filter=`, which the
+/// main url refuses with a cloudflare challenge while the home page keeps loading.
+#[aidoku_test]
+fn listings_test() {
+	let source = source();
+
+	for id in ["latest", "hot", "new", "completed"] {
+		let result = with_retry(|| source.get_manga_list(listing(id), 1));
+
+		assert_entries(&result);
+		pause();
+	}
+}
+
+#[aidoku_test]
+fn search_test() {
+	let source = source();
+	let result =
+		with_retry(|| source.get_search_manga_list(Some("solo leveling".into()), 1, vec![]));
+
+	assert!(result.entries.iter().any(|manga| manga.key == MANGA_KEY));
+}
+
+#[aidoku_test]
+fn manga_details_test() {
+	let manga = source()
+		.get_manga_update(
+			Manga {
+				key: MANGA_KEY.into(),
+				..Default::default()
+			},
+			true,
+			true,
+		)
+		.expect("get_manga_update failed");
+
+	assert_eq!(manga.title, "Solo Leveling");
+	assert!(manga.cover.is_some());
+	assert!(manga.description.is_some());
+	assert!(
+		manga
+			.url
+			.as_deref()
+			.is_some_and(|url| url.ends_with(MANGA_KEY))
+	);
+	// authors, tags, status and viewer are read with `:contains`/`:containsOwn`, jsoup
+	// extensions the test runner's css engine cannot parse, so they only fill in inside the
+	// app and have to be checked there
+
+	let chapters = manga.chapters.expect("no chapters");
+	// the chapter api pages 500 at a time, so this also covers a series past a single page
+	assert!(chapters.len() >= 200);
+
+	for chapter in &chapters {
+		assert!(chapter.key.starts_with(MANGA_KEY));
+		assert!(chapter.chapter_number.is_some());
+		assert!(
+			chapter
+				.url
+				.as_deref()
+				.is_some_and(|url| url.starts_with("https://"))
+		);
+	}
+}
+
+#[aidoku_test]
+fn page_list_test() {
+	let source = source();
+	let mut manga = source
+		.get_manga_update(
+			Manga {
+				key: MANGA_KEY.into(),
+				..Default::default()
+			},
+			false,
+			true,
+		)
+		.expect("get_manga_update failed");
+	let chapter = manga
+		.chapters
+		.take()
+		.and_then(|chapters| chapters.into_iter().next())
+		.expect("no chapters");
+	pause();
+
+	let pages = source
+		.get_page_list(manga, chapter)
+		.expect("get_page_list failed");
+
+	assert!(!pages.is_empty());
+	for page in pages {
+		match page.content {
+			PageContent::Url(url, _) => assert!(url.starts_with("https://")),
+			_ => panic!("expected a url page"),
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`mangakakalot.gg` serves a Cloudflare managed challenge (`403`, `cf-mitigated: challenge`)
on every content path while the home page loads normally, so the Home tab works and every
listing, search and series page fails issue 

The challenge is applied per client, not per path: a web view is served the real page, so no
`cf_clearance` is ever issued for the source's own requests to reuse. That is
Aidoku/Aidoku#1034 and can't be fixed from here.

`mangakakalove.com` is already listed as this source's second url and serves all of those
paths normally, so this makes it selectable.

Related: [#1034](https://github.com/Aidoku/Aidoku/issues/1034), maybe related: #310

## Changes
- Enable `allowsBaseUrlSelect` and leverage the alternate url.
- Read the selected url in `params()`, falling back to `mangakakalot.gg` when unset, so the
  default is unchanged.
- Set `minAppVersion` to `0.7.1`, without which `aidoku verify` fails its api version check.
- Add tests for the listings, search, details and page list.

## Testing

`cargo build --release`, `cargo fmt`, `cargo clippy`, `aidoku package`, `aidoku verify` and
`cargo test -- --test-threads=1` all pass. The tests hit the live site and need a single
thread, since the test runner ignores `set_rate_limit`.

Checked on device: listings, search, details and pages all load with `mangakakalove.com`
selected; switching back to the default reproduces the failure.