### PR TITLE
chore: remove redundant comments

### DIFF
--- a/sources/ja.mangarawbest/src/helpers.rs
+++ b/sources/ja.mangarawbest/src/helpers.rs
@@ -7,8 +7,7 @@ use aidoku::{
 	prelude::*,
 };
 
-/// Sort values accepted by the `sort` query parameter, ordered to match the
-/// options declared in `filters.json`.
+// same order as the options in res/filters.json
 pub const SORT_VALUES: [&str; 8] = [
 	"-updated_at",
 	"-created_at",
@@ -20,16 +19,11 @@ pub const SORT_VALUES: [&str; 8] = [
 	"-name",
 ];
 
-/// Genres that mark a series as explicit.
 const NSFW_TAGS: [&str; 6] = ["成人向け", "成年", "アダルト", "hentai", "adult", "smut"];
 
-/// Genres that mark a series as suggestive but not explicit.
 const SUGGESTIVE_TAGS: [&str; 4] = ["ecchi", "mature", "巨乳", "エッチ"];
 
-/// Parses a Japanese relative date such as "6日前" into a unix timestamp.
-///
-/// The site renders every date through a `timeago` helper, so absolute dates
-/// are never present in the markup.
+// every date is rendered through a `timeago` helper, so the markup never carries an absolute one
 pub fn parse_relative_date(text: &str) -> Option<i64> {
 	let text = text.trim().strip_suffix('前')?;
 	let digits_end = text.find(|c: char| !c.is_ascii_digit())?;
@@ -49,7 +43,6 @@ pub fn parse_relative_date(text: &str) -> Option<i64> {
 	Some(current_date() - amount * seconds)
 }
 
-/// Extracts a chapter number from a title such as "第990話" or "第37.5話".
 pub fn parse_chapter_number(title: &str) -> Option<f32> {
 	// Chapter titles are consistently formatted as 第<number>話, but fall back
 	// to the first number in the string so unusual titles still get a number.
@@ -67,11 +60,7 @@ pub fn parse_chapter_number(title: &str) -> Option<f32> {
 	rest[..end].trim_end_matches('.').parse().ok()
 }
 
-/// Returns true when a chapter title carries nothing beyond the chapter number,
-/// such as "第41話".
-///
-/// Every chapter on this site is named that way, and the app already renders the
-/// number from `chapter_number`, so keeping the title would show it twice.
+// almost every chapter is named "第41話", which the app already renders from `chapter_number`
 pub fn is_plain_chapter_title(title: &str) -> bool {
 	let Some(number) = title
 		.trim()
@@ -84,10 +73,8 @@ pub fn is_plain_chapter_title(title: &str) -> bool {
 	!number.is_empty() && number.chars().all(|c| c.is_ascii_digit() || c == '.')
 }
 
-/// Maps the `filter[status]` value a series page links to onto a status.
-///
-/// The value is preferred over the label next to it ("進行中" / "完了") because
-/// it is what the site filters on, and so is not affected by wording changes.
+// the filter value is read rather than the label next to it ("進行中" / "完了"), which wording
+// changes would break
 pub fn parse_status_value(href: &str) -> Option<&'static str> {
 	// ex: /manga-list?sort=-updated_at&page=1&filter%5Bstatus%5D=2
 	let start = href.rfind('=')? + 1;
@@ -98,10 +85,8 @@ pub fn parse_status_value(href: &str) -> Option<&'static str> {
 	}
 }
 
-/// Derives a content rating from a series' genres.
-///
-/// The site has no rating of its own, but tags such as "成人向け" and "Ecchi"
-/// are assigned consistently enough to classify the explicit entries.
+// the site carries no rating of its own, but tags like "成人向け" and "Ecchi" are assigned
+// consistently enough to classify the explicit entries
 pub fn content_rating_from_tags(tags: &[String]) -> ContentRating {
 	let matches = |list: &[&str], tag: &str| {
 		let tag = tag.to_lowercase();
@@ -117,15 +102,14 @@ pub fn content_rating_from_tags(tags: &[String]) -> ContentRating {
 	}
 }
 
-/// Strips the " raw" suffix the site appends to some of its Japanese genres.
+// the site appends " raw" to some of its japanese genres
 pub fn clean_tag(tag: &str) -> Option<String> {
 	let tag = tag.trim();
 	let tag = tag.strip_suffix(" raw").unwrap_or(tag).trim();
 	(!tag.is_empty()).then(|| tag.to_string())
 }
 
-/// Rewrites a page image url for the given image server, mirroring the
-/// `switchImageServer` helper the site ships in its reader.
+// mirrors the `switchImageServer` helper the site ships in its reader
 pub fn build_image_url(server: &str, original: &str) -> String {
 	match server {
 		"2" => {
@@ -143,7 +127,6 @@ pub fn build_image_url(server: &str, original: &str) -> String {
 	}
 }
 
-/// Extracts the `page` query parameter from a pagination link.
 pub fn parse_page_param(href: &str) -> Option<i32> {
 	let start = href.find("page=")? + "page=".len();
 	let rest = &href[start..];
@@ -153,8 +136,7 @@ pub fn parse_page_param(href: &str) -> Option<i32> {
 	rest[..end].parse().ok()
 }
 
-/// Reduces a series url to its path, tolerating the scheme and host variations
-/// a shared link may use.
+// shared links vary in scheme and host
 pub fn strip_base_url(url: &str) -> Option<&str> {
 	let path = url
 		.strip_prefix("https://")
@@ -164,15 +146,13 @@ pub fn strip_base_url(url: &str) -> Option<&str> {
 	path.strip_prefix("mangaraw.best")
 }
 
-/// Appends `value` to `values` unless it is already present, preserving the
-/// order the site lists them in.
 pub fn push_unique(values: &mut Vec<String>, value: String) {
 	if !values.contains(&value) {
 		values.push(value);
 	}
 }
 
-/// Parses a manga grid page, shared by search, filtering and listings.
+// shared by search, filtering and listings
 pub fn parse_manga_page(html: &Document, page: i32) -> MangaPageResult {
 	let entries = html
 		.select(".manga-vertical")
@@ -226,11 +206,8 @@ pub fn parse_manga_page(html: &Document, page: i32) -> MangaPageResult {
 	}
 }
 
-/// Collects the genres listed on a series page.
-///
-/// Scoped to the genre row of the info block: the page also ends with an SEO
-/// keyword cloud that links to the same genres, but labels each one with the
-/// series title ("<title> Action") and would otherwise pollute the tags.
+// scoped to the genre row of the info block: the page also ends with an SEO keyword cloud linking
+// to the same genres, labelled with the series title ("<title> Action")
 pub fn parse_tags(html: &Document) -> Vec<String> {
 	let mut tags = Vec::new();
 
@@ -245,7 +222,6 @@ pub fn parse_tags(html: &Document) -> Vec<String> {
 	tags
 }
 
-/// Reads the publishing status from the series page.
 pub fn parse_status(html: &Document) -> MangaStatus {
 	let Some(element) = html.select_first("a[href*='status']") else {
 		return MangaStatus::Unknown;
@@ -265,7 +241,6 @@ pub fn parse_status(html: &Document) -> MangaStatus {
 	}
 }
 
-/// Collects the chapter list from a series page.
 pub fn parse_chapters(html: &Document) -> Vec<Chapter> {
 	html.select("#chapterList ul a")
 		.map(|elements| {

--- a/sources/ja.mangarawbest/src/lib.rs
+++ b/sources/ja.mangarawbest/src/lib.rs
@@ -159,7 +159,6 @@ impl Source for MangaRawBest {
 }
 
 impl MangaRawBest {
-	/// Requests a page of the browse grid with an already built query string.
 	fn fetch_manga_page(&self, query: &str, page: i32) -> Result<MangaPageResult> {
 		let html = Request::get(format!("{BASE_URL}/manga-list?{query}"))?.html()?;
 		Ok(parse_manga_page(&html, page))
@@ -234,7 +233,6 @@ mod test {
 	use aidoku::{ContentRating, alloc::vec};
 	use aidoku_test::aidoku_test;
 
-	/// A long-running series that is unlikely to disappear from the site.
 	const SERIES_KEY: &str = "tu-long-nobai";
 
 	fn assert_valid_entries(entries: &[Manga]) {

--- a/sources/ja.mangarawjp/src/helpers.rs
+++ b/sources/ja.mangarawjp/src/helpers.rs
@@ -1,6 +1,6 @@
 use aidoku::alloc::string::String;
 
-/// Strip trailing "Raw Free" and similar suffixes from a title.
+// titles carry a trailing "Raw Free" and similar suffixes
 pub fn clean_title(title: String) -> String {
 	let suffixes = [" Raw Free", " Raw free", " raw free"];
 	for suffix in suffixes {
@@ -11,7 +11,7 @@ pub fn clean_title(title: String) -> String {
 	title
 }
 
-/// Extract chapter number from text like 【第N話】 -> N
+// chapter text looks like 【第N話】
 pub fn extract_ch_number(s: &str) -> Option<f32> {
 	let dai = '第';
 	let wa = '話';

--- a/sources/ja.mangarawjp/src/lib.rs
+++ b/sources/ja.mangarawjp/src/lib.rs
@@ -129,14 +129,14 @@ impl Source for MangaRawJP {
 		let url = format!("{BASE_URL}{}", chapter.key);
 		let html = Request::get(&url)?.html()?;
 
-		// Extract window.MangaId and window.CNumber from inline script tags
+		// the reader is empty and pulls the image list from the api, keyed by ids an inline
+		// script declares
 		// e.g. <script>window.MangaId =  133 ;window.CNumber =  10 </script>
 		let mut manga_id_opt: Option<String> = None;
 		let mut chapter_num_opt: Option<String> = None;
 		if let Some(scripts) = html.select("script") {
 			for script in scripts {
 				if let Some(data) = script.data() {
-					// Look for window.MangaId
 					if let Some(pos) = data.find("window.MangaId") {
 						let after = &data[pos + 14..]; // after "window.MangaId"
 						if let Some(eq_pos) = after.find('=') {
@@ -150,7 +150,6 @@ impl Source for MangaRawJP {
 							}
 						}
 					}
-					// Look for window.CNumber
 					if let Some(pos) = data.find("window.CNumber") {
 						let after = &data[pos + 14..]; // after "window.CNumber"
 						if let Some(eq_pos) = after.find('=') {
@@ -173,7 +172,6 @@ impl Source for MangaRawJP {
 		let manga_id = manga_id_opt.ok_or_else(|| error!("Manga ID not found"))?;
 		let chapter_num = chapter_num_opt.ok_or_else(|| error!("Chapter number not found"))?;
 
-		// Fetch image URL list via JSON API
 		let api_url = format!("{BASE_URL}/api/v1/get/c");
 		let body = format!("{{\"m\":{manga_id},\"n\":{chapter_num}}}");
 
@@ -203,7 +201,6 @@ impl Source for MangaRawJP {
 	}
 }
 
-/// The selected option of the sort filter, falling back to the first one.
 fn sort_index(filters: &[FilterValue]) -> i32 {
 	filters
 		.iter()
@@ -214,13 +211,9 @@ fn sort_index(filters: &[FilterValue]) -> i32 {
 		.unwrap_or(0)
 }
 
-/// Scrapes a paginated listing page into manga entries.
-///
-/// The first page of the updates ordering is the site home page, which stacks
-/// several ".post-list" blocks: the updates list, then the ranking and one block
-/// per featured genre. Only the first block is the paginated list, so entries
-/// are always scoped to it — scraping every block there mixes the rankings and
-/// genre picks into the updates order.
+// the updates ordering starts at the home page, which stacks several ".post-list" blocks: the
+// updates list, then the ranking and one per featured genre. entries are scoped to the first
+// block, since scraping every one of them mixes the rankings and genre picks into the order
 fn parse_listing_page(url: &str) -> Result<MangaPageResult> {
 	let html = Request::get(url)?.html()?;
 
@@ -347,14 +340,11 @@ impl DeepLinkHandler for MangaRawJP {
 		const SERIES_PATH: &str = "/manga-raw/";
 
 		if key.starts_with(SERIES_PATH) {
-			// Determine chapter vs series URL by path segment count
-			// Series:  /manga-raw/TITLE-raw-free/
-			// Chapter: /manga-raw/TITLE-raw-free/第N話/
+			// series: /manga-raw/TITLE-raw-free/, chapter: /manga-raw/TITLE-raw-free/第N話/
 			let trimmed = key.trim_end_matches('/');
 			let segments: Vec<&str> = trimmed.split('/').filter(|s| !s.is_empty()).collect();
 
 			if segments.len() > 2 {
-				// Chapter URL — derive manga key from parent path
 				let manga_key = segments[..2].join("/");
 				let manga_key = format!("/{manga_key}/");
 				Ok(Some(DeepLinkResult::Chapter {
@@ -362,7 +352,6 @@ impl DeepLinkHandler for MangaRawJP {
 					key: key.into(),
 				}))
 			} else {
-				// Series URL
 				Ok(Some(DeepLinkResult::Manga { key: key.into() }))
 			}
 		} else {
@@ -401,7 +390,6 @@ mod test {
 			.expect("browse request should succeed")
 	}
 
-	/// The leading keys of a result, which is what an ordering actually changes.
 	fn leading_keys(result: &MangaPageResult) -> Vec<&String> {
 		result
 			.entries
@@ -411,8 +399,7 @@ mod test {
 			.collect()
 	}
 
-	/// The app sends no filter value until one is picked, so the fallback has to
-	/// be a real ordering rather than an out of range option.
+	// the app sends no filter value until one is picked
 	#[aidoku_test]
 	fn test_sort_index_falls_back_to_the_first_option() {
 		assert_eq!(sort_index(&[]), SORT_UPDATED);
@@ -459,10 +446,8 @@ mod test {
 		assert!(!result.entries.is_empty(), "search should return entries");
 	}
 
-	/// The search endpoint takes no ordering, so a query has to win over whatever
-	/// sort value is still stored while the filter is hidden. Matching the query
-	/// against the titles would not catch a fallback, since the query is also the
-	/// top ranking entry, so the result is compared against the ranking page.
+	// the query is also the top ranking entry, so matching it against the titles wouldn't catch a
+	// fallback to the sort paths. the result is compared against the ranking page instead
 	#[aidoku_test]
 	fn test_query_takes_precedence_over_sort() {
 		let searched = MangaRawJP
@@ -477,8 +462,7 @@ mod test {
 		);
 	}
 
-	/// An empty query is not a search, so it has to fall through to the ordering
-	/// paths instead of hitting the search endpoint with nothing.
+	// an empty query has to fall through to the ordering paths
 	#[aidoku_test]
 	fn test_empty_query_falls_through_to_the_sort() {
 		let result = MangaRawJP
@@ -493,10 +477,7 @@ mod test {
 		);
 	}
 
-	/// The updates ordering starts at the site home page, which stacks the updates
-	/// block together with the ranking and featured genre blocks. Scraping every
-	/// ".post-list" there mixes all four into one page and repeats entries, so
-	/// guard against that regression.
+	// scraping every ".post-list" of the home page mixes all four blocks in and repeats entries
 	#[aidoku_test]
 	fn test_updated_page_1_holds_only_the_updates_block() {
 		let result = browse(SORT_UPDATED, 1);
@@ -518,8 +499,7 @@ mod test {
 		);
 	}
 
-	/// Keys are site-relative paths, which is what "/manga-raw/..." hrefs already
-	/// hold, while covers have to be joined into absolute urls to be fetchable.
+	// keys stay as the site-relative paths the hrefs hold, covers are joined into absolute urls
 	#[aidoku_test]
 	fn test_keys_stay_relative_and_covers_absolute() {
 		let result = browse(SORT_UPDATED, 1);
@@ -538,8 +518,6 @@ mod test {
 		}
 	}
 
-	/// Pages past the end return no entries, which is how the app learns to stop
-	/// paginating.
 	#[aidoku_test]
 	fn test_pagination_ends() {
 		let result = browse(SORT_UPDATED, 9999);
@@ -549,8 +527,7 @@ mod test {
 		);
 	}
 
-	/// Each option has to actually change the order, otherwise the filter is a
-	/// no-op and everything falls back to one ordering.
+	// an option that doesn't change the order means the filter is a no-op
 	#[aidoku_test]
 	fn test_sorts_return_different_orders() {
 		let updated = browse(SORT_UPDATED, 1);

--- a/sources/ja.mangarawjp/src/models.rs
+++ b/sources/ja.mangarawjp/src/models.rs
@@ -1,13 +1,12 @@
 use aidoku::alloc::{string::String, vec::Vec};
 use serde::Deserialize;
 
-/// Response structure for /api/v1/get/c
+// Response of /api/v1/get/c: `c` is the page shuffling key, `e` the image paths
+// ("/public/key/?id=...").
 #[derive(Deserialize)]
 pub struct ChapterApiResponse {
-	/// Page shuffling key
 	#[serde(default)]
 	pub c: String,
-	/// List of image paths ("/public/key/?id=..." format)
 	#[serde(default)]
 	pub e: Vec<String>,
 }

--- a/sources/ja.rawdevart/src/helpers.rs
+++ b/sources/ja.rawdevart/src/helpers.rs
@@ -4,14 +4,13 @@ use aidoku::{
 	imports::html::{Element, Html},
 };
 
-/// Strips the letters the site puts in front of ids in page urls, keeping only what looks like
-/// an id afterwards.
+// page urls put letters in front of the id
 pub fn manga_key(id: &str) -> Option<&str> {
 	let key = id.trim_start_matches(char::is_alphabetic);
 	(!key.is_empty() && key.bytes().all(|byte| byte.is_ascii_digit())).then_some(key)
 }
 
-/// Some descriptions hold markup, which the app doesn't render.
+// some descriptions hold markup, which the app doesn't render
 pub fn strip_html(description: &str) -> String {
 	Html::parse_fragment(description)
 		.ok()
@@ -21,7 +20,7 @@ pub fn strip_html(description: &str) -> String {
 		.into()
 }
 
-/// Derives a content rating from the genres of an entry, which the api doesn't provide directly.
+// the api provides no rating of its own
 pub fn content_rating(tags: &[String]) -> ContentRating {
 	let mut rating = ContentRating::Safe;
 	for tag in tags {

--- a/sources/ja.rawdevart/src/lib.rs
+++ b/sources/ja.rawdevart/src/lib.rs
@@ -18,11 +18,11 @@ use helpers::*;
 use models::*;
 
 const BASE_URL: &str = "https://rawdevart.art";
-/// Page urls prefix numeric ids with two letters that the site ignores when routing.
+// the site ignores these two letters when routing
 const ID_PREFIX: &str = "ne";
 const DATE_FORMAT: &str = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
 
-/// Values of the `sort` query parameter, in the order of the options in "filters.json".
+// same order as the options in res/filters.json
 const SORTS: &[&str] = &["", "most_viewed", "most_viewed_today"];
 
 pub fn manga_url(key: &str) -> String {

--- a/sources/ja.rawdevart/src/models.rs
+++ b/sources/ja.rawdevart/src/models.rs
@@ -7,12 +7,12 @@ use serde::Deserialize;
 
 use crate::{DATE_FORMAT, chapter_url, manga_url};
 
-/// Response of the manga list endpoints (`/spa/latest-manga`, `/spa/genre/*` and `/spa/search`).
+// `/spa/latest-manga`, `/spa/genre/*` and `/spa/search`
 #[derive(Deserialize)]
 pub struct MangaListResponse {
 	pub manga_list: Vec<MangaEntry>,
 	pub pagi: Option<Pagination>,
-	/// Markup of the genre `<select>`, only returned by the genre endpoints.
+	// markup of the genre `<select>`, only returned by the genre endpoints
 	#[serde(rename = "genreOpt")]
 	pub genre_opt: Option<String>,
 }
@@ -24,11 +24,10 @@ pub struct Pagination {
 
 #[derive(Deserialize)]
 pub struct PaginationButton {
-	/// The next page number, or zero when the current page is the last one.
+	// zero on the last page
 	pub next: i32,
 }
 
-/// A manga as returned in a listing, holding just enough to display a cover.
 #[derive(Deserialize)]
 pub struct MangaEntry {
 	pub manga_id: i64,
@@ -51,10 +50,8 @@ impl From<MangaEntry> for Manga {
 	}
 }
 
-/// Response of `/spa/manga/{manga_id}`, holding both details and the chapter list.
-///
-/// Every field is optional: a single unexpected null anywhere in the response would otherwise
-/// fail the whole deserialization, leaving the entry with no chapters at all.
+// `/spa/manga/{manga_id}`. every field is optional: a single unexpected null would otherwise fail
+// the whole deserialization, leaving the entry with no chapters at all
 #[derive(Deserialize)]
 pub struct MangaDetailsResponse {
 	#[serde(default)]
@@ -71,7 +68,7 @@ pub struct MangaDetailsResponse {
 pub struct MangaEntryDetail {
 	pub manga_name: Option<String>,
 	pub manga_description: Option<String>,
-	/// Whether the series has finished publishing.
+	// true once the series has finished publishing
 	pub manga_status: Option<bool>,
 	pub manga_cover_img: Option<String>,
 	pub manga_cover_img_full: Option<String>,
@@ -89,14 +86,14 @@ pub struct Author {
 
 #[derive(Deserialize)]
 pub struct ChapterEntry {
-	/// Also used as the chapter key, since that's what the page endpoint takes.
+	// also the chapter key, since that's what the page endpoint takes
 	pub chapter_number: Option<f32>,
 	pub chapter_title: Option<String>,
 	pub chapter_date_published: Option<String>,
 }
 
 impl ChapterEntry {
-	/// Returns nothing when the entry has no number, since it can't be requested without one.
+	// an entry without a number can't be requested
 	pub fn into_chapter(self, manga_key: &str) -> Option<Chapter> {
 		let number = self.chapter_number?;
 		let key = number.to_string();
@@ -121,7 +118,7 @@ impl ChapterEntry {
 	}
 }
 
-/// Response of `/spa/manga/{manga_id}/{chapter_number}`.
+// `/spa/manga/{manga_id}/{chapter_number}`
 #[derive(Deserialize)]
 pub struct ChapterPagesResponse {
 	#[serde(default)]
@@ -130,11 +127,10 @@ pub struct ChapterPagesResponse {
 
 #[derive(Deserialize)]
 pub struct ChapterDetail {
-	/// Markup holding one lazily loaded `img` per page.
+	// markup holding one lazily loaded `img` per page
 	pub chapter_content: Option<String>,
-	/// Base url the page images are relative to.
+	// base url the page images are relative to, with `servers` holding its mirrors
 	pub server: Option<String>,
-	/// Mirrors of `server`, used when it isn't provided.
 	#[serde(default)]
 	pub slaves: Option<Vec<String>>,
 }

--- a/sources/ja.soraraw/src/helpers.rs
+++ b/sources/ja.soraraw/src/helpers.rs
@@ -12,26 +12,23 @@ use serde::de::DeserializeOwned;
 
 use crate::{BASE_URL, HEADER_BYTES, MAX_DRAWABLE_HEIGHT, THUMBNAIL_URL, models::NextData};
 
-/// Block size of the cipher the site encrypts image paths with.
 const BLOCK_SIZE: usize = 16;
 
 pub fn manga_url(slug: &str) -> String {
 	format!("{BASE_URL}/manga/{slug}")
 }
 
-/// Chapter paths repeat the slug of their manga, which the url they're reachable at doesn't.
+// chapter paths repeat the slug of their manga, which the url doesn't
 pub fn chapter_url(manga_slug: &str, path: &str) -> String {
 	let suffix = path.strip_prefix(&format!("{manga_slug}-")).unwrap_or(path);
 	format!("{BASE_URL}/manga/{manga_slug}/{suffix}")
 }
 
-/// Chapter keys hold both ids the image endpoint takes, so requesting pages never has to rely on
-/// the slug of a manga carrying its id.
+// both ids the image endpoint takes, so pages never rely on a slug carrying its id
 pub fn chapter_key(manga_id: i64, chapter_id: i64) -> String {
 	format!("{manga_id}/{chapter_id}")
 }
 
-/// Listing pages put the page number in the path, and only from the second page on.
 pub fn paginated(url: &str, page: i32) -> String {
 	if page > 1 {
 		format!("{url}/page/{page}")
@@ -40,7 +37,6 @@ pub fn paginated(url: &str, page: i32) -> String {
 	}
 }
 
-/// Reads the "__NEXT_DATA__" blob a page embeds, which holds everything it renders from.
 pub fn next_data<T: DeserializeOwned>(url: &str) -> Result<T> {
 	let html = Request::get(url)?.html()?;
 	// script contents are data nodes rather than text, so `text` would come back empty. `data` is
@@ -58,7 +54,7 @@ pub fn next_data<T: DeserializeOwned>(url: &str) -> Result<T> {
 		.map_err(|error| AidokuError::Message(format!("unexpected page data at {url}: {error}")))
 }
 
-/// Synopses hold inline markup, which the app doesn't render.
+// synopses hold inline markup, which the app doesn't render
 pub fn strip_html(text: &str) -> String {
 	// wrapped in an element of its own: reading the text off a bare fragment works in the app but
 	// not in the test runner, which only ever hands back elements a selector matched
@@ -71,7 +67,6 @@ pub fn strip_html(text: &str) -> String {
 		.into()
 }
 
-/// Reads the height of an image off its header, without pulling the whole file down.
 fn image_height(url: &str) -> Option<u32> {
 	let range = format!("bytes=0-{}", HEADER_BYTES - 1);
 	let head = Request::get(url)
@@ -82,15 +77,10 @@ fn image_height(url: &str) -> Option<u32> {
 	jpeg_height(&head)
 }
 
-/// Refuses an image the reader can't put on screen.
-///
-/// A few chapters ship as a single image stacking every page of them, standing 49152 pixels tall,
-/// which runs past the texture size the gpu takes. Cutting one into pages the reader can draw
-/// isn't something a source can do today: `Canvas::copy_image` and `draw_image` place the
-/// destination rect off the canvas whenever it is shorter than the image drawn from, so every
-/// slice comes back a flat colour (Aidoku/AidokuRunner#3). Saying so beats handing back a black
-/// page the reader can't tell apart from a download that failed. Once that lands, slicing becomes
-/// worth adding: the stacked images cut cleanly on 2048 pixel boundaries.
+// a few chapters ship as one image stacking every page, up to 49152 pixels tall. slicing those
+// isn't possible yet: `Canvas::copy_image` and `draw_image` place the destination rect off the
+// canvas when it is shorter than the source, so every slice comes back a flat colour
+// (Aidoku/AidokuRunner#3). failing beats handing back a blank page
 pub fn check_drawable(url: &str) -> Result<()> {
 	match image_height(url) {
 		Some(height) if height > MAX_DRAWABLE_HEIGHT => bail!(
@@ -100,10 +90,7 @@ pub fn check_drawable(url: &str) -> Result<()> {
 	}
 }
 
-/// Reads the height in pixels out of the header of a jpeg, given the opening bytes of the file.
-///
-/// Only jpeg needs measuring: webp caps a side at 16383 pixels, which the reader still handles, so
-/// a webp page can never be too tall to draw.
+// only jpeg needs measuring: webp caps a side at 16383 pixels, which the reader still draws
 pub fn jpeg_height(head: &[u8]) -> Option<u32> {
 	fn length(head: &[u8], at: usize) -> Option<usize> {
 		Some(usize::from(u16::from_be_bytes([
@@ -134,7 +121,7 @@ pub fn jpeg_height(head: &[u8]) -> Option<u32> {
 	None
 }
 
-/// Listings hand out either a full cover url or just the file name on the thumbnail host.
+// listings hand out either a full cover url or just the file name on the thumbnail host
 pub fn cover(thumbnail: Option<String>, image: Option<&str>) -> Option<String> {
 	thumbnail
 		.filter(|thumbnail| !thumbnail.is_empty())
@@ -145,7 +132,6 @@ pub fn cover(thumbnail: Option<String>, image: Option<&str>) -> Option<String> {
 		})
 }
 
-/// Authors come as a single comma separated field.
 pub fn authors(author: Option<&str>) -> Option<Vec<String>> {
 	let authors = author?
 		.split(',')
@@ -163,19 +149,11 @@ pub fn status(kind: Option<&str>) -> MangaStatus {
 	}
 }
 
-/// Picks the reader from the genres a series carries, which is the only field that tracks what the
-/// artwork actually is.
-///
-/// The `mode` field looks like the obvious input and isn't: it says how the site's own reader lays
-/// a series out, not what kind of comic it is. Measured across 31 series, every `horizontal` one
-/// held page-shaped art — but so did a third of the `vertical` ones, ordinary japanese manga that
-/// the app would otherwise open in a continuous scroll. The overseas genres track the content
-/// instead: across 8000 catalogue entries they appear on 2 of 7021 `horizontal` series and on 644
-/// of 979 `vertical` ones, which is the share of `vertical` series that really are webtoons.
-///
-/// Image proportions are deliberately not used either. Korean webtoons here are cut into
-/// page-shaped chunks about as often as into tall strips, so the shape of a page says nothing
-/// about whether the panels are meant to run together.
+// the `mode` field says how the site's own reader lays a series out, not what kind of comic it
+// is: a third of the `vertical` ones are ordinary manga. the overseas genres track the content
+// instead, appearing on 644 of 979 `vertical` entries and on 2 of 7021 `horizontal` ones.
+// image proportions don't work either, since webtoons here are as often cut into page-shaped
+// chunks as into tall strips
 pub fn viewer<'a>(genre_slugs: impl Iterator<Item = &'a str>) -> Viewer {
 	const OVERSEAS_GENRE: &str = "kaigai-manga";
 
@@ -188,12 +166,8 @@ pub fn viewer<'a>(genre_slugs: impl Iterator<Item = &'a str>) -> Viewer {
 	Viewer::RightToLeft
 }
 
-/// Every entry carries the flag the site sorts adult content by, which is what this follows.
-///
-/// Deriving anything further from the genres of a series was tried and dropped: genre names are
-/// not unique (41 of the 1834 the site lists are used by more than one genre), and the ones that
-/// read as suggestive are already flagged as adult by the site itself, so a name based guess
-/// disagreed with the site more often than it added anything.
+// deriving anything further from genres was tried and dropped: names are not unique (41 of the
+// 1834 listed are shared), and the suggestive ones are already flagged as adult by the site
 pub fn content_rating(is_adult: Option<&str>) -> ContentRating {
 	match is_adult {
 		Some("yes") => ContentRating::NSFW,
@@ -202,10 +176,8 @@ pub fn content_rating(is_adult: Option<&str>) -> ContentRating {
 	}
 }
 
-/// Case insensitive substring search that doesn't allocate.
-///
-/// Comparing bytes is safe for the utf-8 the catalogue holds: a multi-byte character can never
-/// match part of another one, so a byte window that compares equal is always a real substring.
+// comparing bytes is safe for utf-8: a multi-byte character can never match part of another one,
+// so a byte window that compares equal is always a real substring
 pub fn contains_ignore_ascii_case(haystack: &str, needle: &str) -> bool {
 	let needle = needle.as_bytes();
 	if needle.is_empty() {
@@ -217,8 +189,7 @@ pub fn contains_ignore_ascii_case(haystack: &str, needle: &str) -> bool {
 		.any(|window| window.eq_ignore_ascii_case(needle))
 }
 
-/// Decodes the base64 payload the image endpoint returns, accepting both the standard and the url
-/// safe alphabet and treating padding as optional, the same way the site's own decoder does.
+// both alphabets and optional padding are accepted, the same way the site's own decoder does
 pub fn decode_base64(input: &str) -> Option<Vec<u8>> {
 	let mut output = Vec::with_capacity(input.len() / 4 * 3);
 	let mut buffer = 0u32;
@@ -246,8 +217,7 @@ pub fn decode_base64(input: &str) -> Option<Vec<u8>> {
 	Some(output)
 }
 
-/// Turns the payload of the image endpoint back into the json it was built from. The site xors it
-/// with a fixed key, which is the only thing standing between the endpoint and a page list.
+// the image endpoint hands out its page list xored with a fixed key
 pub fn deobfuscate(payload: &str, key: &[u8]) -> Option<String> {
 	if key.is_empty() {
 		return None;
@@ -266,12 +236,9 @@ pub fn deobfuscate(payload: &str, key: &[u8]) -> Option<String> {
 	(!json.is_empty()).then(|| json.to_string())
 }
 
-/// Turns the encrypted path of a page entry back into the path its image is served at. The site
-/// xors the value with a fixed secret and encrypts what's left with aes-256-ctr, keyed on the uuid
-/// its chapter page carries.
-///
-/// Building the path out of the ids instead only holds for part of the site: the file extension
-/// varies per chapter, and guessing it leaves whole series answering 404.
+// page paths are xored with a fixed secret and encrypted with aes-256-ctr, keyed on the uuid the
+// chapter page carries. building the path out of the ids instead only holds for part of the site:
+// the file extension varies per chapter, and guessing it leaves whole series answering 404
 pub fn decrypt_path(payload: &str, uuid: &str, secret: &[u8]) -> Option<String> {
 	if secret.is_empty() {
 		return None;
@@ -307,7 +274,6 @@ pub fn decrypt_path(payload: &str, uuid: &str, secret: &[u8]) -> Option<String> 
 	String::from_utf8(path).ok().filter(|path| !path.is_empty())
 }
 
-/// Counts the counter block up the way the site's cipher does, as one big endian number.
 fn increment(counter: &mut [u8; BLOCK_SIZE]) {
 	for byte in counter.iter_mut().rev() {
 		*byte = byte.wrapping_add(1);

--- a/sources/ja.soraraw/src/lib.rs
+++ b/sources/ja.soraraw/src/lib.rs
@@ -15,31 +15,23 @@ use helpers::*;
 use models::*;
 
 const BASE_URL: &str = "https://soraraw.com";
-/// Host the cover images are served from.
 const THUMBNAIL_URL: &str = "https://i.mangaraw.lat";
-/// Endpoint holding the page list of a chapter, which no page of the site embeds.
 const IMAGE_API_URL: &str = "https://api.mangarawgo.site";
 const DATE_FORMAT: &str = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
-/// Key the site xors the payload of the image endpoint with.
 const PAYLOAD_KEY: &[u8] = b"/fuCkYou!!!";
-/// Secret the site xors an encrypted image path with before deciphering it.
 const PATH_SECRET: &[u8] = b"202508055d0db38bae2e86cc41649f90";
-/// How many images a chapter may hold before they're taken as one page each. A chapter served as
-/// a strip holds a handful of images at most, while a scanned one holds an image per page, so this
-/// keeps the request that measures them off the common case.
+// a strip holds a handful of images at most, a scanned chapter one per page, so this keeps the
+// request that measures them off the common case
 const STRIP_IMAGE_LIMIT: usize = 4;
-/// Tallest image the reader can put on screen, being the texture size the gpu takes.
+// the texture size the gpu takes
 const MAX_DRAWABLE_HEIGHT: u32 = 16384;
-/// How much of an image to read to find its size in. The size sits in the header, ahead of the
-/// scan data, so the opening kilobytes hold it unless the file leads with a large colour profile.
+// enough to reach the header unless the file leads with a large colour profile
 const HEADER_BYTES: usize = 16 * 1024;
-/// How many genres to offer as filter options. The site lists over 1800 of them, most holding a
-/// handful of entries, and hands them out sorted by how many series they hold.
+// the site lists over 1800 genres, sorted by how many series they hold
 const GENRE_LIMIT: usize = 100;
-/// How many matches to collect before leaving the rest of the catalogue alone.
 const SEARCH_RESULT_LIMIT: usize = 50;
-/// Upper bound on the catalogue pages a search walks. The dump held 13 at the time of writing and
-/// ends with a 404; this only guards against a host that stops answering with one.
+// the dump held 13 pages at the time of writing and ends with a 404; this only guards against a
+// host that stops answering with one
 const CATALOGUE_PAGE_LIMIT: i32 = 40;
 
 struct Soraraw;
@@ -205,18 +197,10 @@ impl Source for Soraraw {
 }
 
 impl Soraraw {
-	/// Searches the catalogue dump the site publishes, because nothing else on it can be queried.
-	///
-	/// An entry has to satisfy every term it is handed: "query" runs over the same fields the
-	/// site's own search does, while "author" narrows to the author alone. Both being `None` would
-	/// match the whole catalogue, so the caller only walks it once it holds one of them.
-	///
-	/// "/search?q=" renders a fixed batch that ignores the query entirely — the page it serves is
-	/// statically generated, and the browser filters a catalogue it downloads itself. The api host
-	/// the site is configured with does expose "/search", but it answers 500 for every query
-	/// (`Unknown column 'Manga.number_views' in 'ORDER BY'`), and its "/mangas" endpoint ignores
-	/// every query parameter it was tried with. That leaves walking the same dump, which is 13
-	/// pages of 2000 entries and around 4.7 MB over the wire with the gzip the host serves.
+	// nothing on the site can be queried: "/search?q=" is statically generated and renders a fixed
+	// batch, the api host answers 500 for every query (`Unknown column 'Manga.number_views' in
+	// 'ORDER BY'`), and its "/mangas" ignores every parameter tried. that leaves walking the dump
+	// the browser filters itself, 13 pages of 2000 entries and about 4.7 MB gzipped
 	fn search_catalogue(query: Option<&str>, author: Option<&str>) -> Result<Vec<Manga>> {
 		let mut entries = Vec::new();
 

--- a/sources/ja.soraraw/src/models.rs
+++ b/sources/ja.soraraw/src/models.rs
@@ -13,7 +13,6 @@ use crate::{
 	},
 };
 
-/// Wrapper of the "__NEXT_DATA__" blob every page embeds.
 #[derive(Deserialize)]
 pub struct NextData<T> {
 	pub props: Props<T>,
@@ -25,13 +24,12 @@ pub struct Props<T> {
 	pub page_props: T,
 }
 
-/// Page props of every page but the home page, which carries an extra list.
 #[derive(Deserialize)]
 pub struct DataProps<T> {
 	pub data: T,
 }
 
-/// Page props of "/", the only page holding both the popular and the trending lists.
+// "/" is the only page holding both the popular and the trending lists
 #[derive(Deserialize)]
 pub struct HomeProps {
 	pub data: ListData,
@@ -45,10 +43,10 @@ pub struct Trending {
 	pub mangas: Vec<MangaEntry>,
 }
 
-/// Data of the paginated listing pages ("/", "/newest" and "/genre/{slug}").
+// "/", "/newest" and "/genre/{slug}"
 #[derive(Deserialize)]
 pub struct ListData {
-	/// Popular entries, only filled in on the home page.
+	// only filled in on the home page
 	#[serde(default)]
 	pub hot: Vec<MangaEntry>,
 	#[serde(default)]
@@ -68,20 +66,14 @@ impl Pagination {
 	}
 }
 
-/// A manga as it appears in a listing or in the search results.
-///
-/// The listings don't all carry the same fields, so everything but the two the app needs to show
-/// a cover is optional here.
+// listings don't all carry the same fields, so everything but the two a cover needs is optional
 #[derive(Deserialize)]
 pub struct MangaEntry {
 	pub name: String,
 	pub slug: String,
 	pub author: Option<String>,
-	/// Cover file name on the thumbnail host.
 	pub image: Option<String>,
-	/// Full cover url, which only the home and genre listings provide.
 	pub thumbnail: Option<String>,
-	/// Publishing status, either "incomplete" or "complete".
 	#[serde(rename = "type")]
 	pub kind: Option<String>,
 	pub is_adult: Option<String>,
@@ -90,7 +82,7 @@ pub struct MangaEntry {
 impl From<MangaEntry> for Manga {
 	fn from(value: MangaEntry) -> Self {
 		// `viewer` is left unset: listings carry no genres, and the reader is picked from those.
-		// The app fills it in from `get_manga_update` before a chapter can be opened anyway
+		// the app fills it in from `get_manga_update` before a chapter can be opened anyway
 		Manga {
 			cover: cover(value.thumbnail, value.image.as_deref()),
 			title: value.name.trim().into(),
@@ -104,22 +96,20 @@ impl From<MangaEntry> for Manga {
 	}
 }
 
-/// One page of "/mangas_{n}.json", the catalogue dump the site searches through in the browser.
+// "/mangas_{n}.json", the catalogue dump the site searches through in the browser
 #[derive(Deserialize)]
 pub struct CataloguePage {
 	#[serde(default)]
 	pub list: Vec<CatalogueEntry>,
 }
 
-/// A catalogue entry, which names some of its fields differently from the listing entries.
 #[derive(Deserialize)]
 pub struct CatalogueEntry {
 	pub name: String,
 	pub slug: String,
-	/// Alternative titles, given as one comma separated field.
 	pub alt_names: Option<String>,
 	pub author: Option<String>,
-	/// Cover file name on the thumbnail host, called "img" here and "image" everywhere else.
+	// the cover file name, called "image" everywhere else
 	pub img: Option<String>,
 	#[serde(rename = "type")]
 	pub kind: Option<String>,
@@ -127,9 +117,8 @@ pub struct CatalogueEntry {
 }
 
 impl CatalogueEntry {
-	/// Matches the same three fields the site's own search runs over. It puts them through a
-	/// fuzzy matcher, which this doesn't reproduce: a plain substring match keeps the walk over
-	/// 24k entries allocation free, and japanese titles are searched by substring anyway.
+	// the same three fields the site's own search runs over. its fuzzy matcher isn't reproduced:
+	// a plain substring match keeps the walk over 24k entries allocation free
 	pub fn matches(&self, needle: &str) -> bool {
 		[
 			Some(self.name.as_str()),
@@ -141,7 +130,7 @@ impl CatalogueEntry {
 		.any(|field| contains_ignore_ascii_case(field, needle))
 	}
 
-	/// Matches the author alone, for the search field that "supportsAuthorSearch" enables.
+	// for the search field "supportsAuthorSearch" enables
 	pub fn matches_author(&self, needle: &str) -> bool {
 		self.author
 			.as_deref()
@@ -166,7 +155,7 @@ impl From<CatalogueEntry> for Manga {
 	}
 }
 
-/// Data of "/manga/{slug}".
+// "/manga/{slug}"
 #[derive(Deserialize)]
 pub struct MangaData {
 	pub manga: Option<MangaDetails>,
@@ -179,9 +168,8 @@ pub struct MangaDetails {
 	pub slug: String,
 	pub author: Option<String>,
 	pub image: Option<String>,
-	/// Always null in practice; the synopsis lives in "content" instead.
+	// always null in practice; the synopsis lives in "content" as an Editor.js document
 	pub description: Option<String>,
-	/// Editor.js document holding the synopsis.
 	pub content: Option<String>,
 	#[serde(rename = "type")]
 	pub kind: Option<String>,
@@ -205,8 +193,6 @@ impl MangaDetails {
 		authors(self.author.as_deref())
 	}
 
-	/// Reads the synopsis out of the Editor.js document the site stores it as, falling back to
-	/// the plain field for the entries that happen to fill it in.
 	pub fn description(&self) -> Option<String> {
 		if let Some(description) = self.description.as_deref().map(strip_html)
 			&& !description.is_empty()
@@ -239,7 +225,7 @@ impl MangaDetails {
 #[derive(Deserialize)]
 pub struct Genre {
 	pub name: String,
-	/// Stable identifier of the genre; names are not unique, so the reader is picked from this.
+	// names are not unique, so the reader is picked from the slug
 	pub slug: String,
 }
 
@@ -250,7 +236,6 @@ impl Genre {
 	}
 }
 
-/// A block document as produced by Editor.js, which the site stores synopses in.
 #[derive(Deserialize)]
 pub struct EditorDocument {
 	#[serde(default)]
@@ -264,17 +249,14 @@ pub struct EditorBlock {
 
 #[derive(Deserialize)]
 pub struct EditorBlockData {
-	/// Holds inline markup, so it can't be used as it is.
 	pub text: Option<String>,
 }
 
 #[derive(Deserialize)]
 pub struct ChapterEntry {
 	pub id: i64,
-	/// Chapter number, given as a number for most entries and as a string for a few.
 	pub name: Option<Number>,
 	pub title: Option<String>,
-	/// Slug of the chapter, prefixed with the slug of the manga it belongs to.
 	pub path: String,
 	pub published_at: Option<String>,
 }
@@ -299,7 +281,7 @@ impl ChapterEntry {
 	}
 }
 
-/// Data of "/manga/{slug}/{chapter}", read only to resolve deep links.
+// "/manga/{slug}/{chapter}", read only to resolve deep links
 #[derive(Deserialize)]
 pub struct ChapterData {
 	pub chapter: Option<ChapterDetails>,
@@ -309,31 +291,25 @@ pub struct ChapterData {
 pub struct ChapterDetails {
 	pub id: i64,
 	pub manga_id: i64,
-	/// Key the paths of the chapter's images are encrypted with. Only the chapter page carries it,
-	/// which is why requesting pages has to read one.
+	// the image paths are encrypted with this, and only the chapter page carries it
 	pub uuid: Option<String>,
-	/// Host the chapter's images are served from.
 	#[serde(rename = "_b")]
 	pub base: Option<String>,
 }
 
-/// Response of the image endpoint, which hands out the page list as an obfuscated payload.
 #[derive(Deserialize)]
 pub struct ImagePayload {
 	pub d: String,
 }
 
-/// A page as listed in the decoded payload.
 #[derive(Deserialize)]
 pub struct PageImage {
 	pub order: Number,
-	/// Path the image is served at, encrypted. Entries also carry a `d` naming the same file on the
-	/// mirror the site keeps on google drive, which is left unread: not every entry holds one, so
-	/// reading from it would leave some chapters short of pages.
+	// the encrypted image path. entries also carry a `d` naming the same file on the google drive
+	// mirror, which is left unread: not every entry holds one
 	pub b: String,
 }
 
-/// A value the site gives as either a number or a string, depending on the entry.
 #[derive(Deserialize)]
 #[serde(untagged)]
 pub enum Number {
@@ -350,7 +326,7 @@ impl Number {
 	}
 }
 
-/// An entry of "/genres.json", used to build the genre filter.
+// "/genres.json"
 #[derive(Deserialize)]
 pub struct GenreEntry {
 	pub name: String,

--- a/sources/ja.soraraw/src/test.rs
+++ b/sources/ja.soraraw/src/test.rs
@@ -2,20 +2,13 @@ use super::*;
 use aidoku::{AidokuError, ContentRating, FilterKind, MangaStatus, Viewer};
 use aidoku_test::aidoku_test;
 
-/// "Majo to Youhei", a long running series used to check parsing against.
 const MANGA_KEY: &str = "majo-to-youhei-57539";
-/// "Mattan Heishi ga Kunshu ni Naru made", a korean webtoon carrying the overseas genre.
 const WEBTOON_KEY: &str = "mattan-heishi-ga-kunshu-ni-naru-made-7194";
-/// "Blue Giant Momentum", ordinary manga the site marks as `vertical`. Reported as opening in a
-/// continuous scroll, which is what picking the reader from `mode` used to do to it.
+// both are marked `vertical` by the site while holding page-shaped art
 const PAGED_VERTICAL_KEY: &str = "blue-giant-momentum-buruu-jaianto-momentamu-60652";
-/// "Hard Worker Nakata", also marked `vertical` while holding page-shaped art.
 const ADULT_VERTICAL_KEY: &str = "haadowaakaa-nakata-740";
-/// "Tonari no Kurokawa-san", which holds one of the chapters stored as jpg.
 const JPG_MANGA_KEY: &str = "my-neighbor-ms-kurokawa-tonari-no-kurokawa-san-1";
 const JPG_CHAPTER_KEY: &str = "1/786104";
-/// "Kobayashi-san Chi no Maid Dragon", used to check that searching finds a series by both its
-/// japanese and its english title.
 const SEARCHED_KEY: &str = "kobayashi-san-chino-meidoragon-57605";
 
 fn listing(id: &str) -> Listing {
@@ -92,9 +85,8 @@ fn test_listing_pagination() {
 	assert!(!hot.has_next_page);
 }
 
-// searching walks the catalogue dump, because the site's own "/search" page answers with the same
-// fixed batch no matter what it is asked for. the series below is looked up by its japanese title
-// and by its romanised alternative one, which has to match regardless of case
+// the series below is looked up by its japanese title and by its romanised alternative one,
+// which has to match regardless of case
 #[aidoku_test]
 fn test_search() {
 	for query in ["小林さんちのメイドラゴン", "miss kobayashi"] {
@@ -145,9 +137,8 @@ fn test_search_by_author() {
 	assert!(!result.has_next_page);
 }
 
-// the author field narrows to the author column alone. the walk above cannot tell that apart from
-// one that ran over every field, since the plain query matches the author too — so the narrowing
-// is pinned here instead, where a title that only the query should match has to be rejected
+// the walk above can't tell the narrowing apart from a plain query, which matches the author too,
+// so it is pinned here: a title that only the query should match has to be rejected
 #[aidoku_test]
 fn test_matches_author() {
 	let entry = serde_json::from_str::<CatalogueEntry>(
@@ -256,9 +247,7 @@ fn test_manga_details() {
 	// parses on device
 }
 
-// the reader is picked from genres rather than from the `mode` field: the site marks plenty of
-// ordinary manga as `vertical`, and reading that flag as "webtoon" handed those to the continuous
-// scroll reader, which ran every page of a chapter together
+// reading `mode` as the reader handed ordinary manga marked `vertical` to the continuous scroll
 #[aidoku_test]
 fn test_viewer_and_content_rating() {
 	for (key, viewer, rating) in [
@@ -336,11 +325,8 @@ fn test_page_list() {
 	);
 }
 
-// at least chapters 66 to 70 of this series are each served as one image holding all 24 of
-// their pages stacked on top of each other, 49152 pixels tall. The reader can't draw that and
-// no cut a source can make reaches into it while Aidoku/AidokuRunner#3 stands, so the chapter
-// has to fail with a reason rather than hand back a page that renders blank. Getting as far as
-// the refusal also means the decrypted path resolved and its header read back
+// chapters 66 to 70 are each served as one image stacking all 24 pages, 49152 pixels tall.
+// reaching the refusal also proves the decrypted path resolved and its header read back
 #[aidoku_test]
 fn test_stacked_chapter_is_refused() {
 	let manga = Manga {
@@ -366,9 +352,8 @@ fn test_stacked_chapter_is_refused() {
 	assert!(reason.contains("49152"), "{reason}");
 }
 
-// stacked chapters are not one series' quirk: this one holds 21 pages in a single 800x24003
-// jpg, so it has to be refused the same way. The chapter has to come from the chapter list
-// rather than be built by hand — its url is where the key to the paths is read from
+// not one series' quirk: this one holds 21 pages in a single 800x24003 jpg. the chapter comes
+// from the chapter list rather than built by hand, since its url carries the key to the paths
 #[aidoku_test]
 fn test_stacked_chapter_of_another_series_is_refused() {
 	let manga = Manga {


### PR DESCRIPTION
Removes doc comments that restate what the code already says, along with the
step-by-step commentary left over from the initial implementations.

These four sources carry the most `///` comments in the repo (133, 40, 32 and 21)
out of the 15 sources that use them at all. What remains is only what can't be
read off the code itself: site quirks, API behaviour, and the reasoning behind
approaches that were tried and dropped.

- **ja.soraraw**: constant and struct field docs dropped; `check_drawable` 9 lines
  to 4, `viewer` 13 to 5, `search_catalogue` 12 to 4
- **ja.mangarawbest**: 18 helper docs cut down to their reasons (timeago helper,
  SEO keyword cloud, `switchImageServer`)
- **ja.mangarawjp**: 6 test function docs shortened, `parse_listing_page` 7 lines
  to 3, `models.rs` aligned with ja.spoilerplus since both read the same
  `/api/v1/get/c`, and the running commentary in `get_page_list` removed
- **ja.rawdevart**: field docs on the response models dropped, endpoint names kept

No code was touched: `git diff -U0` with comment lines filtered out is empty.
253 lines removed, 108 added.

`cargo fmt`, `cargo clippy --release`, `cargo test --release`, `aidoku package`
and `aidoku verify` pass for all four sources (18, 19, 12 and 9 tests).

Versions are left as they are, since comments don't reach the built wasm. Happy
to bump them if that's preferred.