### PR TITLE
fix(multi.kagane): rank search results by relevance

### DIFF
--- a/sources/multi.kagane/res/filters.json
+++ b/sources/multi.kagane/res/filters.json
@@ -4,7 +4,18 @@
 		"id": "sort",
 		"title": "Sort By",
 		"canAscend": false,
-		"options": ["Popular (Total Views)", "Recently Updated", "Recently Added"],
+		"options": [
+			"Relevance",
+			"Popular (Total Views)",
+			"Popular (Average Views)",
+			"Popular (Today)",
+			"Popular (Week)",
+			"Popular (Month)",
+			"Recently Updated",
+			"By Name",
+			"Books Count",
+			"Recently Added"
+		],
 		"default": { "index": 0, "ascending": false }
 	},
 	{

--- a/sources/multi.kagane/res/source.json
+++ b/sources/multi.kagane/res/source.json
@@ -2,7 +2,7 @@
 	"info": {
 		"id": "multi.kagane",
 		"name": "Kagane",
-		"version": 2,
+		"version": 3,
 		"url": "https://kagane.to",
 		"minAppVersion": "0.7.1",
 		"contentRating": 1,

--- a/sources/multi.kagane/src/helpers.rs
+++ b/sources/multi.kagane/src/helpers.rs
@@ -7,6 +7,32 @@ use aidoku::{
 pub const BASE_URL: &str = "https://kagane.to";
 pub const API_BASE: &str = "https://kagane.to/api/v2";
 
+/// Sort field by the position of the option in `res/filters.json`.
+pub const SORT_PARAMS: &[&str] = &[
+	"",                // 0: Relevance
+	"total_views",     // 1: Popular (Total Views)
+	"avg_views",       // 2: Popular (Average Views)
+	"avg_views_today", // 3: Popular (Today)
+	"avg_views_week",  // 4: Popular (Week)
+	"avg_views_month", // 5: Popular (Month)
+	"updated_at",      // 6: Recently Updated
+	"series_name",     // 7: By Name
+	"books_count",     // 8: Books Count
+	"created_at",      // 9: Recently Added
+];
+
+pub fn search_url(query: Option<&str>, page: i32, sort_idx: usize) -> String {
+	let query = query.filter(|q| !q.is_empty());
+	let mut url = format!("{API_BASE}/search/series?page={}&size=35", page - 1);
+	let sort = SORT_PARAMS.get(sort_idx).copied().unwrap_or_default();
+	if !sort.is_empty() {
+		url.push_str(&format!("&sort={sort},desc"));
+	} else if query.is_none() {
+		url.push_str("&sort=total_views,desc");
+	}
+	url
+}
+
 pub fn api_get(url: &str) -> Result<Request> {
 	Ok(Request::get(url)?
 		.header("Origin", BASE_URL)

--- a/sources/multi.kagane/src/lib.rs
+++ b/sources/multi.kagane/src/lib.rs
@@ -17,13 +17,6 @@ mod models;
 use helpers::*;
 use models::*;
 
-// Sort param by filter index (from filters.json options order).
-const SORT_PARAMS: &[&str] = &[
-	"total_views", // 0: Popular (Total Views)
-	"updated_at",  // 1: Recently Updated
-	"created_at",  // 2: Recently Added
-];
-
 struct Kagane;
 
 impl Source for Kagane {
@@ -67,13 +60,14 @@ impl Source for Kagane {
 			}
 		}
 
-		let sort = SORT_PARAMS.get(sort_idx).unwrap_or(&"total_views");
-		let url = format!(
-			"{API_BASE}/search/series?page={}&size=35&sort={},desc",
-			page - 1,
-			sort
+		let url = search_url(query.as_deref(), page, sort_idx);
+		let body = build_search_body(
+			query.as_deref(),
+			&statuses,
+			&formats,
+			&genres_inc,
+			&genres_exc,
 		);
-		let body = build_search_body(query.as_deref(), &statuses, &formats, &genres_inc, &genres_exc);
 		let resp: SearchResponse = api_post(&url, body)?.json_owned()?;
 
 		let has_next_page = !resp.last;


### PR DESCRIPTION
Searching always added `sort=total_views,desc` to a request when no sort filters are added, which replaced the api's own relevance sorting. This is bad because the api then returns every series whose title somewhat matched the search term, ordered by popularity, so an exact match can land very deep inside the results. Example series I used was "The Villainess Lives Again", which has 3 letter to letter matches on site, but the source doesn't return a single one in app. The intended behaviour should be to leave the entire sort parameter out so the source returns by Relevance (new sort filter), which causes the three matches to actually appear at the top.

While I was here I also added the other missing sort filters the api accepts:  Popular (Today), Popular (Week), Popular (Month), By Name, and Books Count.

And I defaulted search to relevance so searching is a little more reliable.