### PR TITLE
fix(ja.soraraw): tolerate null genre rows

### DIFF
--- a/sources/ja.soraraw/res/source.json
+++ b/sources/ja.soraraw/res/source.json
@@ -2,7 +2,7 @@
 	"info": {
 		"id": "ja.soraraw",
 		"name": "Soraraw",
-		"version": 1,
+		"version": 2,
 		"url": "https://soraraw.com",
 		"contentRating": 2,
 		"languages": [

--- a/sources/ja.soraraw/src/models.rs
+++ b/sources/ja.soraraw/src/models.rs
@@ -186,7 +186,7 @@ impl MangaDetails {
 	}
 
 	pub fn viewer(&self) -> Viewer {
-		viewer(self.genres.iter().map(|genre| genre.slug.as_str()))
+		viewer(self.genres.iter().filter_map(|genre| genre.slug.as_deref()))
 	}
 
 	pub fn authors(&self) -> Option<Vec<String>> {
@@ -222,16 +222,17 @@ impl MangaDetails {
 	}
 }
 
+// a few series hold genre rows the site never filled in, every field but the id null
 #[derive(Deserialize)]
 pub struct Genre {
-	pub name: String,
+	pub name: Option<String>,
 	// names are not unique, so the reader is picked from the slug
-	pub slug: String,
+	pub slug: Option<String>,
 }
 
 impl Genre {
 	pub fn into_tag(self) -> Option<String> {
-		let tag = String::from(self.name.trim());
+		let tag = String::from(self.name?.trim());
 		(!tag.is_empty()).then_some(tag)
 	}
 }

--- a/sources/ja.soraraw/src/test.rs
+++ b/sources/ja.soraraw/src/test.rs
@@ -10,6 +10,7 @@ const ADULT_VERTICAL_KEY: &str = "haadowaakaa-nakata-740";
 const JPG_MANGA_KEY: &str = "my-neighbor-ms-kurokawa-tonari-no-kurokawa-san-1";
 const JPG_CHAPTER_KEY: &str = "1/786104";
 const SEARCHED_KEY: &str = "kobayashi-san-chino-meidoragon-57605";
+const NULL_GENRE_KEY: &str = "majime-fumajime-maji-koiji-64273";
 
 fn listing(id: &str) -> Listing {
 	Listing {
@@ -245,6 +246,21 @@ fn test_manga_details() {
 	// date_uploaded isn't checked here: the test runner doesn't implement the quoting,
 	// fractional seconds or ISO 8601 zones that DATE_FORMAT relies on, so it only ever
 	// parses on device
+}
+
+// two of its genre rows come back with every field but the id null, which used to fail the whole
+// details request
+#[aidoku_test]
+fn test_null_genres() {
+	let manga = Manga {
+		key: String::from(NULL_GENRE_KEY),
+		..Default::default()
+	};
+	let manga = Soraraw
+		.get_manga_update(manga, true, true)
+		.expect("manga details");
+
+	assert!(manga.tags.is_some_and(|tags| !tags.is_empty()));
 }
 
 // reading `mode` as the reader handed ordinary manga marked `vertical` to the continuous scroll


### PR DESCRIPTION
## Summary

Fetching details for a series whose genre list holds an empty row fails the whole request, so the
series cannot be opened at all.

`Genre` declared `name` and `slug` as `String`. A few series carry genre rows the site never filled
in — every field but the id is `null` — and `serde` rejects the row, which fails the deserialization
of the entire page payload. The series then returns an error instead of details or chapters.

This widens both fields to `Option<String>`:

- `Genre::into_tag` drops a row with no name, alongside the existing check that drops an empty one
- `MangaDetails::viewer` picks the reader from the slugs that are present, using `filter_map`
  instead of `map`

Nothing else changes. A series with ordinary genre rows behaves exactly as before.

## The rows in question

`majime-fumajime-maji-koiji-64273` is the example the test uses. Its `genres` array:

```json
[
  { "id": 12,   "name": "日常",       "slug": "nichijou" },
  { "id": 17,   "name": "コメディ",   "slug": "komedi" },
  { "id": 24,   "name": "ロマンス",   "slug": "romansu" },
  { "id": 2211, "name": null,         "slug": null },
  { "id": 2212, "name": null,         "slug": null }
]
```

Ids 2211 and 2212 are absent from `genres.json`, which lists 1909 genres, none of them null. So
these look like rows the site deleted from the genre table while leaving the join rows behind — the
manga page joins against the missing ids and gets nulls back. That makes it a data-shape the source
has to tolerate rather than something the site is likely to clean up.

## Testing

19 tests pass, including a new `test_null_genres`, which fetches the series above and asserts the
details request succeeds and still returns the three real genres as tags. It fails against the
previous revision with `unexpected page data`.

`cargo fmt`, `cargo clippy --release`, `cargo test --release`, `aidoku package` and
`aidoku verify package.aix` are all clean.

Not device tested — the fix is in deserialization and the test runner exercises the same path.

## `version` — needs a decision

Set to 2 here, but #697 also raises it from 1 to 2 for the same source. Whichever merges second
needs 3 instead. I have left both at 2 rather than guess at the merge order; tell me which one you
would like to take first and I will rebase the other and set the number.

The two changes do not otherwise overlap: this one touches `models.rs`, #697 touches `helpers.rs`
and `lib.rs`, and the only shared file is `res/source.json` on that one line.

This is the smaller and more clearly scoped of the two, and it fixes series that currently do not
open at all, so it may be worth taking first regardless of where #697 lands.
