### PR TITLE
feat(mangareader): split stacked chapter images into pages

### DIFF
--- a/sources/ja.mangamura/res/source.json
+++ b/sources/ja.mangamura/res/source.json
@@ -2,10 +2,11 @@
 	"info": {
 		"id": "ja.mangamura",
 		"name": "Manga Mura",
-		"version": 3,
+		"version": 4,
 		"url": "https://mangamura.me",
 		"contentRating": 1,
-		"languages": ["ja"]
+		"languages": ["ja"],
+		"minAppVersion": "0.9"
 	},
 	"listings": [
 		{

--- a/sources/ja.mangamura/src/lib.rs
+++ b/sources/ja.mangamura/src/lib.rs
@@ -3,10 +3,7 @@ use aidoku::{Source, alloc::borrow::Cow, prelude::*};
 use mangareader::{Impl, MangaReader, Params};
 
 const BASE_URL: &str = "https://mangamura.me";
-// some chapters ship as one tall jpeg stacking every page into it. a page stands about 1.42 times
-// its width here: across 33 stacked images the ratio ran from 1.39 to 1.44, and the nominal b5 √2
-// rounds 1115x56000 up to 36 pages, where 56000/35 lands on a whole 1600 like every other page
-// height read off the site
+// some chapters ship as one tall jpeg; across 33 of them a page ran 1.39 to 1.44 times its width
 const PAGE_ASPECT: f32 = 1.42;
 
 struct MangaMura;
@@ -26,8 +23,7 @@ impl Impl for MangaMura {
 			page_param: "p".into(),
 			get_chapter_selector: || "#ja-chaps > li".into(),
 			get_chapter_language: |_| "ja".into(),
-			// the chapter name only ever repeats the number, sometimes with a volume suffix or the
-			// seo heading wrapped around it
+			// chapter names only ever repeat the number
 			has_chapter_titles: false,
 			get_page_url_path: |chapter_id| format!("/json/chapter?id={chapter_id}&mode=vertical"),
 			set_default_filters: |query_params| {

--- a/sources/ja.mangamura/src/lib.rs
+++ b/sources/ja.mangamura/src/lib.rs
@@ -3,6 +3,11 @@ use aidoku::{Source, alloc::borrow::Cow, prelude::*};
 use mangareader::{Impl, MangaReader, Params};
 
 const BASE_URL: &str = "https://mangamura.me";
+// some chapters ship as one tall jpeg stacking every page into it. a page stands about 1.42 times
+// its width here: across 33 stacked images the ratio ran from 1.39 to 1.44, and the nominal b5 √2
+// rounds 1115x56000 up to 36 pages, where 56000/35 lands on a whole 1600 like every other page
+// height read off the site
+const PAGE_ASPECT: f32 = 1.42;
 
 struct MangaMura;
 
@@ -15,10 +20,15 @@ impl Impl for MangaMura {
 		Params {
 			base_url: BASE_URL.into(),
 			search_path: "".into(),
+			// the site has no /home; the root carries the same layout
+			home_path: "/".into(),
 			search_param: "q".into(),
 			page_param: "p".into(),
 			get_chapter_selector: || "#ja-chaps > li".into(),
 			get_chapter_language: |_| "ja".into(),
+			// the chapter name only ever repeats the number, sometimes with a volume suffix or the
+			// seo heading wrapped around it
+			has_chapter_titles: false,
 			get_page_url_path: |chapter_id| format!("/json/chapter?id={chapter_id}&mode=vertical"),
 			set_default_filters: |query_params| {
 				query_params.set("type", Some("all"));
@@ -26,6 +36,7 @@ impl Impl for MangaMura {
 				query_params.set("language", Some("all"));
 				query_params.set("sort", Some("default"));
 			},
+			stacked_page_ratio: Some(PAGE_ASPECT),
 			..Default::default()
 		}
 	}
@@ -48,51 +59,9 @@ register_source!(
 	ListingProvider,
 	Home,
 	ImageRequestProvider,
+	PageImageProcessor,
 	DeepLinkHandler
 );
 
 #[cfg(test)]
-mod test {
-	use super::*;
-	use aidoku::alloc::{String, vec::Vec};
-	use aidoku_test::aidoku_test;
-
-	fn source() -> MangaReader<MangaMura> {
-		Source::new()
-	}
-
-	// The site links entries with absolute urls, so keys are only stripped down
-	// to paths when BASE_URL matches the live domain. A stale domain silently
-	// turns every key into a full url and breaks details and chapter lists.
-	#[aidoku_test]
-	fn search_returns_path_keys() {
-		let result = source()
-			.get_search_manga_list(Some(String::from("ワンピース")), 1, Vec::new())
-			.expect("search failed");
-		assert!(!result.entries.is_empty(), "expected at least one result");
-		for manga in &result.entries {
-			assert!(
-				manga.key.starts_with('/'),
-				"expected a path key, got {}",
-				manga.key
-			);
-		}
-	}
-
-	#[aidoku_test]
-	fn manga_details_have_chapters() {
-		let source = source();
-		let manga = source
-			.get_search_manga_list(Some(String::from("ワンピース")), 1, Vec::new())
-			.expect("search failed")
-			.entries
-			.into_iter()
-			.next()
-			.expect("expected at least one result");
-		let manga = source
-			.get_manga_update(manga, true, true)
-			.expect("get_manga_update failed");
-		let chapters = manga.chapters.expect("no chapters returned");
-		assert!(chapters.len() > 100, "got {} chapters", chapters.len());
-	}
-}
+mod test;

--- a/sources/ja.mangamura/src/test.rs
+++ b/sources/ja.mangamura/src/test.rs
@@ -31,9 +31,8 @@ fn fetch_chapter(key: &str, number: f32) -> (Manga, Chapter) {
 	(manga, chapter)
 }
 
-// The site links entries with absolute urls, so keys are only stripped down
-// to paths when BASE_URL matches the live domain. A stale domain silently
-// turns every key into a full url and breaks details and chapter lists.
+// entries are linked with absolute urls, so a stale BASE_URL leaves every key a full url and
+// breaks details and chapter lists
 #[aidoku_test]
 fn search_returns_path_keys() {
 	let result = source()
@@ -160,8 +159,7 @@ fn home_has_entries() {
 	assert!(filled > 2, "only {filled} components carry entries");
 }
 
-// every chapter name on the site repeats the number, either bare, with a volume suffix, or
-// wrapped in the seo heading, so nothing is left to show as a title
+// every chapter name repeats the number, bare or with a volume suffix or the seo heading
 #[aidoku_test]
 fn chapters_carry_no_title() {
 	let manga = Manga {

--- a/sources/ja.mangamura/src/test.rs
+++ b/sources/ja.mangamura/src/test.rs
@@ -1,0 +1,187 @@
+use super::*;
+use aidoku::{
+	Chapter, Home, HomeComponentValue, Manga, PageContent,
+	alloc::{String, vec::Vec},
+};
+use aidoku_test::aidoku_test;
+use mangareader::helper::slice_count;
+
+const STACKED_MANGA_KEY: &str = "/manga/小林さんちのメイドラゴン-イルルは恋とかわかりません！-raw/";
+const PAGED_MANGA_KEY: &str = "/manga/せっかく農家に転生したので勇者は目指しません-raw/";
+
+fn source() -> MangaReader<MangaMura> {
+	Source::new()
+}
+
+fn fetch_chapter(key: &str, number: f32) -> (Manga, Chapter) {
+	let manga = Manga {
+		key: String::from(key),
+		..Default::default()
+	};
+	let mut manga = source()
+		.get_manga_update(manga, false, true)
+		.expect("get_manga_update failed");
+	let chapter = manga
+		.chapters
+		.take()
+		.expect("no chapters returned")
+		.into_iter()
+		.find(|chapter| chapter.chapter_number == Some(number))
+		.unwrap_or_else(|| panic!("chapter {number} is gone"));
+	(manga, chapter)
+}
+
+// The site links entries with absolute urls, so keys are only stripped down
+// to paths when BASE_URL matches the live domain. A stale domain silently
+// turns every key into a full url and breaks details and chapter lists.
+#[aidoku_test]
+fn search_returns_path_keys() {
+	let result = source()
+		.get_search_manga_list(Some(String::from("ワンピース")), 1, Vec::new())
+		.expect("search failed");
+	assert!(!result.entries.is_empty(), "expected at least one result");
+	for manga in &result.entries {
+		assert!(
+			manga.key.starts_with('/'),
+			"expected a path key, got {}",
+			manga.key
+		);
+	}
+}
+
+#[aidoku_test]
+fn manga_details_have_chapters() {
+	let source = source();
+	let manga = source
+		.get_search_manga_list(Some(String::from("ワンピース")), 1, Vec::new())
+		.expect("search failed")
+		.entries
+		.into_iter()
+		.next()
+		.expect("expected at least one result");
+	let manga = source
+		.get_manga_update(manga, true, true)
+		.expect("get_manga_update failed");
+	let chapters = manga.chapters.expect("no chapters returned");
+	assert!(chapters.len() > 100, "got {} chapters", chapters.len());
+}
+
+// chapter 1 is served as one 800x18208 jpg stacking all 16 pages
+#[aidoku_test]
+fn stacked_chapter_is_split() {
+	let (manga, chapter) = fetch_chapter(STACKED_MANGA_KEY, 1.0);
+	let pages = source().get_page_list(manga, chapter).expect("pages");
+	assert!(pages.len() > 8, "got {} pages", pages.len());
+
+	let mut first_url = None;
+	for (index, page) in pages.iter().enumerate() {
+		let PageContent::Url(url, Some(context)) = &page.content else {
+			panic!("page {index} carries no slice");
+		};
+		let first_url = first_url.get_or_insert_with(|| url.clone());
+		assert_eq!(url, first_url, "the slices come off one image");
+		assert_eq!(
+			context.get("slice").map(|slice| slice.parse::<usize>()),
+			Some(Ok(index)),
+			"slice {index} is out of order"
+		);
+		assert_eq!(
+			context.get("slices").map(|slices| slices.parse::<usize>()),
+			Some(Ok(pages.len())),
+			"the slice count does not match the pages handed over"
+		);
+	}
+}
+
+// a chapter holding a page per image is handed over untouched
+#[aidoku_test]
+fn paged_chapter_is_left_alone() {
+	let (manga, chapter) = fetch_chapter(PAGED_MANGA_KEY, 1.0);
+	let pages = source().get_page_list(manga, chapter).expect("pages");
+	assert!(pages.len() > 4, "got {} pages", pages.len());
+	for (index, page) in pages.iter().enumerate() {
+		let PageContent::Url(_, context) = &page.content else {
+			panic!("page {index} is not a url");
+		};
+		assert!(context.is_none(), "page {index} was sliced");
+	}
+}
+
+// sizes read off the site, and headers too broken to measure
+#[aidoku_test]
+fn slice_count_matches_measured_images() {
+	assert_eq!(slice_count_at(800, 18208), 16);
+	assert_eq!(slice_count_at(800, 27312), 24);
+	assert_eq!(slice_count_at(1426, 53248), 26);
+	assert_eq!(slice_count_at(1115, 56000), 35);
+	// 38912 / 19 lands on 2048; the plain ratio rounds 19.53 up to 20 and cuts every page
+	assert_eq!(slice_count_at(1403, 38912), 19);
+	assert_eq!(slice_count_at(1125, 64000), 40);
+	assert_eq!(slice_count_at(650, 924), 1);
+	assert_eq!(slice_count_at(0, 49152), 1);
+	assert_eq!(slice_count_at(0, 0), 1);
+	assert_eq!(slice_count_at(100, 49152), 1);
+}
+
+fn slice_count_at(width: u32, height: u32) -> u32 {
+	slice_count(width, height, PAGE_ASPECT)
+}
+
+#[aidoku_test]
+fn manga_details_fill_title() {
+	let manga = Manga {
+		key: String::from(STACKED_MANGA_KEY),
+		..Default::default()
+	};
+	let manga = source()
+		.get_manga_update(manga, true, false)
+		.expect("get_manga_update failed");
+	assert_eq!(
+		manga.title,
+		"小林さんちのメイドラゴン イルルは恋とかわかりません！"
+	);
+}
+
+#[aidoku_test]
+fn home_has_entries() {
+	let home = source().get_home().expect("get_home failed");
+	assert!(!home.components.is_empty(), "no home components");
+	let filled = home
+		.components
+		.iter()
+		.filter(|component| match &component.value {
+			HomeComponentValue::BigScroller { entries, .. } => !entries.is_empty(),
+			HomeComponentValue::Scroller { entries, .. } => !entries.is_empty(),
+			HomeComponentValue::MangaList { entries, .. } => !entries.is_empty(),
+			HomeComponentValue::MangaChapterList { entries, .. } => !entries.is_empty(),
+			_ => false,
+		})
+		.count();
+	assert!(filled > 2, "only {filled} components carry entries");
+}
+
+// every chapter name on the site repeats the number, either bare, with a volume suffix, or
+// wrapped in the seo heading, so nothing is left to show as a title
+#[aidoku_test]
+fn chapters_carry_no_title() {
+	let manga = Manga {
+		key: String::from("/manga/約束のネバーランド-raw/"),
+		..Default::default()
+	};
+	let manga = source()
+		.get_manga_update(manga, false, true)
+		.expect("get_manga_update failed");
+	let chapters = manga.chapters.expect("no chapters returned");
+	assert!(
+		chapters.iter().any(|c| c.chapter_number == Some(181.6)),
+		"the decimal chapter is gone"
+	);
+	for chapter in &chapters {
+		assert!(
+			chapter.title.is_none(),
+			"chapter {:?} kept the title {:?}",
+			chapter.chapter_number,
+			chapter.title
+		);
+	}
+}

--- a/sources/ja.mangamura/src/test.rs
+++ b/sources/ja.mangamura/src/test.rs
@@ -4,7 +4,7 @@ use aidoku::{
 	alloc::{String, vec::Vec},
 };
 use aidoku_test::aidoku_test;
-use mangareader::helper::slice_count;
+use mangareader::slice_count;
 
 const STACKED_MANGA_KEY: &str = "/manga/小林さんちのメイドラゴン-イルルは恋とかわかりません！-raw/";
 const PAGED_MANGA_KEY: &str = "/manga/せっかく農家に転生したので勇者は目指しません-raw/";

--- a/sources/ja.rawotaku/res/source.json
+++ b/sources/ja.rawotaku/res/source.json
@@ -2,10 +2,11 @@
 	"info": {
 		"id": "ja.rawotaku",
 		"name": "Raw Otaku",
-		"version": 1,
+		"version": 2,
 		"url": "https://rawotaku.com",
 		"contentRating": 1,
-		"languages": ["ja"]
+		"languages": ["ja"],
+		"minAppVersion": "0.9"
 	},
 	"listings": [
 		{

--- a/sources/ja.rawotaku/src/lib.rs
+++ b/sources/ja.rawotaku/src/lib.rs
@@ -3,8 +3,7 @@ use aidoku::{Source, alloc::borrow::Cow, prelude::*};
 use mangareader::{Impl, MangaReader, Params};
 
 const BASE_URL: &str = "https://rawotaku.com";
-// some chapters ship as one tall jpeg stacking every page into it. a page stands about 1.42
-// times its width here, measured across the stacked images the site serves
+// some chapters ship as one tall jpeg; a page stands about 1.42 times its width here
 const PAGE_ASPECT: f32 = 1.42;
 
 struct RawOtaku;
@@ -22,8 +21,7 @@ impl Impl for RawOtaku {
 			page_param: "p".into(),
 			get_chapter_selector: || "#ja-chaps > li".into(),
 			get_chapter_language: |_| "ja".into(),
-			// the chapter name only ever repeats the number, sometimes with a volume suffix or the
-			// seo heading wrapped around it
+			// chapter names only ever repeat the number
 			has_chapter_titles: false,
 			get_page_url_path: |chapter_id| format!("/json/chapter?id={chapter_id}&mode=vertical"),
 			set_default_filters: |query_params| {

--- a/sources/ja.rawotaku/src/lib.rs
+++ b/sources/ja.rawotaku/src/lib.rs
@@ -1,8 +1,11 @@
 #![no_std]
-use aidoku::{alloc::borrow::Cow, prelude::*, Source};
+use aidoku::{Source, alloc::borrow::Cow, prelude::*};
 use mangareader::{Impl, MangaReader, Params};
 
 const BASE_URL: &str = "https://rawotaku.com";
+// some chapters ship as one tall jpeg stacking every page into it. a page stands about 1.42
+// times its width here, measured across the stacked images the site serves
+const PAGE_ASPECT: f32 = 1.42;
 
 struct RawOtaku;
 
@@ -19,6 +22,9 @@ impl Impl for RawOtaku {
 			page_param: "p".into(),
 			get_chapter_selector: || "#ja-chaps > li".into(),
 			get_chapter_language: |_| "ja".into(),
+			// the chapter name only ever repeats the number, sometimes with a volume suffix or the
+			// seo heading wrapped around it
+			has_chapter_titles: false,
 			get_page_url_path: |chapter_id| format!("/json/chapter?id={chapter_id}&mode=vertical"),
 			set_default_filters: |query_params| {
 				query_params.set("type", Some("all"));
@@ -26,6 +32,7 @@ impl Impl for RawOtaku {
 				query_params.set("language", Some("all"));
 				query_params.set("sort", Some("default"));
 			},
+			stacked_page_ratio: Some(PAGE_ASPECT),
 			..Default::default()
 		}
 	}
@@ -48,5 +55,9 @@ register_source!(
 	ListingProvider,
 	Home,
 	ImageRequestProvider,
+	PageImageProcessor,
 	DeepLinkHandler
 );
+
+#[cfg(test)]
+mod test;

--- a/sources/ja.rawotaku/src/test.rs
+++ b/sources/ja.rawotaku/src/test.rs
@@ -1,0 +1,142 @@
+use super::*;
+use aidoku::{
+	Chapter, Manga, PageContent,
+	alloc::{String, vec::Vec},
+};
+use aidoku_test::aidoku_test;
+use mangareader::helper::slice_count;
+
+const STACKED_MANGA_KEY: &str = "/read/お風呂はまた明日-raw/";
+const PAGED_MANGA_KEY: &str = "/read/せっかく農家に転生したので勇者は目指しません-raw/";
+
+fn source() -> MangaReader<RawOtaku> {
+	Source::new()
+}
+
+fn fetch_chapter(key: &str, number: f32) -> (Manga, Chapter) {
+	let manga = Manga {
+		key: String::from(key),
+		..Default::default()
+	};
+	let mut manga = source()
+		.get_manga_update(manga, false, true)
+		.expect("get_manga_update failed");
+	let chapter = manga
+		.chapters
+		.take()
+		.expect("no chapters returned")
+		.into_iter()
+		.find(|chapter| chapter.chapter_number == Some(number))
+		.unwrap_or_else(|| panic!("chapter {number} is gone"));
+	(manga, chapter)
+}
+
+#[aidoku_test]
+fn search_returns_path_keys() {
+	let result = source()
+		.get_search_manga_list(Some(String::from("ワンピース")), 1, Vec::new())
+		.expect("search failed");
+	assert!(!result.entries.is_empty(), "expected at least one result");
+	for manga in &result.entries {
+		assert!(
+			manga.key.starts_with('/'),
+			"expected a path key, got {}",
+			manga.key
+		);
+	}
+}
+
+// chapter 1 is served as one 1426x53248 jpg stacking all 26 pages
+#[aidoku_test]
+fn stacked_chapter_is_split() {
+	let (manga, chapter) = fetch_chapter(STACKED_MANGA_KEY, 1.0);
+	let pages = source().get_page_list(manga, chapter).expect("pages");
+	assert!(pages.len() > 8, "got {} pages", pages.len());
+
+	let mut first_url = None;
+	for (index, page) in pages.iter().enumerate() {
+		let PageContent::Url(url, Some(context)) = &page.content else {
+			panic!("page {index} carries no slice");
+		};
+		let first_url = first_url.get_or_insert_with(|| url.clone());
+		assert_eq!(url, &*first_url, "the slices come off one image");
+		assert_eq!(
+			context.get("slice").map(|slice| slice.parse::<usize>()),
+			Some(Ok(index)),
+			"slice {index} is out of order"
+		);
+		assert_eq!(
+			context.get("slices").map(|slices| slices.parse::<usize>()),
+			Some(Ok(pages.len())),
+			"the slice count does not match the pages handed over"
+		);
+	}
+}
+
+// a chapter holding a page per image is handed over untouched
+#[aidoku_test]
+fn paged_chapter_is_left_alone() {
+	let (manga, chapter) = fetch_chapter(PAGED_MANGA_KEY, 1.0);
+	let pages = source().get_page_list(manga, chapter).expect("pages");
+	assert!(pages.len() > 4, "got {} pages", pages.len());
+	for (index, page) in pages.iter().enumerate() {
+		let PageContent::Url(_, context) = &page.content else {
+			panic!("page {index} is not a url");
+		};
+		assert!(context.is_none(), "page {index} was sliced");
+	}
+}
+
+// sizes read off the site, and headers too broken to measure
+#[aidoku_test]
+fn slice_count_matches_measured_images() {
+	assert_eq!(slice_count_at(1426, 53248), 26);
+	assert_eq!(slice_count_at(800, 64809), 57);
+	assert_eq!(slice_count_at(1125, 64000), 40);
+	assert_eq!(slice_count_at(800, 5673), 5);
+	assert_eq!(slice_count_at(1125, 1600), 1);
+	assert_eq!(slice_count_at(0, 49152), 1);
+	assert_eq!(slice_count_at(0, 0), 1);
+	assert_eq!(slice_count_at(100, 49152), 1);
+}
+
+fn slice_count_at(width: u32, height: u32) -> u32 {
+	slice_count(width, height, PAGE_ASPECT)
+}
+
+#[aidoku_test]
+fn manga_details_fill_title() {
+	let manga = Manga {
+		key: String::from(STACKED_MANGA_KEY),
+		..Default::default()
+	};
+	let manga = source()
+		.get_manga_update(manga, true, false)
+		.expect("get_manga_update failed");
+	assert_eq!(manga.title, "お風呂はまた明日");
+}
+
+// same as mangamura: the chapter name only ever repeats the number
+#[aidoku_test]
+fn chapters_carry_no_title() {
+	let manga = Manga {
+		key: String::from("/read/痛覚探偵-通天寺ナツメ-［超感覚者たちの華麗なる事件記録］-raw/"),
+		..Default::default()
+	};
+	let manga = source()
+		.get_manga_update(manga, false, true)
+		.expect("get_manga_update failed");
+	let chapters = manga.chapters.expect("no chapters returned");
+	assert!(
+		chapters.iter().any(|c| c.chapter_number == Some(8.2)),
+		"the decimal chapter is gone"
+	);
+	for chapter in &chapters {
+		assert!(
+			chapter.title.is_none(),
+			"chapter {:?} kept the title {:?}",
+			chapter.chapter_number,
+			chapter.title
+		);
+	}
+}

--- a/sources/ja.rawotaku/src/test.rs
+++ b/sources/ja.rawotaku/src/test.rs
@@ -4,7 +4,7 @@ use aidoku::{
 	alloc::{String, vec::Vec},
 };
 use aidoku_test::aidoku_test;
-use mangareader::helper::slice_count;
+use mangareader::slice_count;
 
 const STACKED_MANGA_KEY: &str = "/read/お風呂はまた明日-raw/";
 const PAGED_MANGA_KEY: &str = "/read/せっかく農家に転生したので勇者は目指しません-raw/";

--- a/templates/mangareader/src/helper.rs
+++ b/templates/mangareader/src/helper.rs
@@ -6,8 +6,7 @@ use aidoku::{
 
 // enough to reach the frame header unless the file leads with a large colour profile
 const HEADER_BYTES: usize = 16 * 1024;
-// the deepest stacked image measured holds 57 pages. a count past this comes from a misread
-// header rather than an image that deep, and slicing on it would hand the reader slivers
+// the deepest stacked image measured holds 57 pages; past this the header was misread
 const STACKED_PAGE_LIMIT: u32 = 64;
 
 pub trait ElementImageAttr {
@@ -44,16 +43,10 @@ fn image_size(url: &str) -> Option<(u32, u32)> {
 pub fn slice_count(width: u32, height: u32, page_ratio: f32) -> u32 {
 	let page_height = width as f32 * page_ratio;
 	let pages = height as f32 / page_height;
-	// `f32::round` is not in core. a width of zero divides into infinity, which saturates to
-	// `u32::MAX` and falls past the limit below rather than wrapping
 	let rounded = (pages + 0.5) as u32;
 	if !(2..=STACKED_PAGE_LIMIT).contains(&rounded) {
 		return 1;
 	}
-
-	// the site cuts its pages at a whole pixel, so the neighbour the ratio leans towards beats it
-	// when the image divides evenly there: 1403x38912 sits at 19.53 pages and rounds to 20, where
-	// 19 leaves a page of exactly 2048 and 20 cuts every one of them
 	let neighbour = if pages < rounded as f32 {
 		rounded - 1
 	} else {
@@ -67,7 +60,7 @@ pub fn slice_count(width: u32, height: u32, page_ratio: f32) -> u32 {
 	rounded
 }
 
-// the stacked images are jpeg; webp caps a side at 16383 pixels, too short to stack a chapter into
+// stacked images are jpeg: webp caps a side at 16383 pixels, too short to stack a chapter into
 fn jpeg_size(head: &[u8]) -> Option<(u32, u32)> {
 	fn length(head: &[u8], at: usize) -> Option<usize> {
 		Some(usize::from(u16::from_be_bytes([
@@ -83,11 +76,11 @@ fn jpeg_size(head: &[u8]) -> Option<(u32, u32)> {
 	let mut index = 2;
 	while *head.get(index)? == 0xFF {
 		match *head.get(index + 1)? {
-			// padding written ahead of the next marker
+			// padding ahead of the next marker
 			0xFF => index += 1,
-			// markers standing on their own, without a segment behind them
+			// markers with no segment behind them
 			0x01 | 0xD0..=0xD9 => index += 2,
-			// a frame header, which opens with the precision and then the size of the image
+			// frame header: precision, then the size
 			0xC0..=0xC3 | 0xC5..=0xC7 | 0xC9..=0xCB | 0xCD..=0xCF => {
 				let height = length(head, index + 5)?.try_into().ok()?;
 				let width = length(head, index + 7)?.try_into().ok()?;

--- a/templates/mangareader/src/helper.rs
+++ b/templates/mangareader/src/helper.rs
@@ -1,4 +1,14 @@
-use aidoku::{alloc::String, imports::html::Element};
+use aidoku::{
+	alloc::String,
+	imports::{html::Element, net::Request},
+	prelude::*,
+};
+
+// enough to reach the frame header unless the file leads with a large colour profile
+const HEADER_BYTES: usize = 16 * 1024;
+// the deepest stacked image measured holds 57 pages. a count past this comes from a misread
+// header rather than an image that deep, and slicing on it would hand the reader slivers
+const STACKED_PAGE_LIMIT: u32 = 64;
 
 pub trait ElementImageAttr {
 	fn img_attr(&self) -> Option<String>;
@@ -12,4 +22,80 @@ impl ElementImageAttr for Element {
 			.or_else(|| self.attr("abs:src"))
 			.or_else(|| self.attr("data-url"))
 	}
+}
+
+pub fn stacked_page_count(url: &str, page_ratio: f32) -> u32 {
+	let Some((width, height)) = image_size(url) else {
+		return 1;
+	};
+	slice_count(width, height, page_ratio)
+}
+
+fn image_size(url: &str) -> Option<(u32, u32)> {
+	let range = format!("bytes=0-{}", HEADER_BYTES - 1);
+	let head = Request::get(url)
+		.ok()?
+		.header("Range", range.as_str())
+		.data()
+		.ok()?;
+	jpeg_size(&head)
+}
+
+pub fn slice_count(width: u32, height: u32, page_ratio: f32) -> u32 {
+	let page_height = width as f32 * page_ratio;
+	let pages = height as f32 / page_height;
+	// `f32::round` is not in core. a width of zero divides into infinity, which saturates to
+	// `u32::MAX` and falls past the limit below rather than wrapping
+	let rounded = (pages + 0.5) as u32;
+	if !(2..=STACKED_PAGE_LIMIT).contains(&rounded) {
+		return 1;
+	}
+
+	// the site cuts its pages at a whole pixel, so the neighbour the ratio leans towards beats it
+	// when the image divides evenly there: 1403x38912 sits at 19.53 pages and rounds to 20, where
+	// 19 leaves a page of exactly 2048 and 20 cuts every one of them
+	let neighbour = if pages < rounded as f32 {
+		rounded - 1
+	} else {
+		rounded + 1
+	};
+	for count in [rounded, neighbour] {
+		if (2..=STACKED_PAGE_LIMIT).contains(&count) && height.is_multiple_of(count) {
+			return count;
+		}
+	}
+	rounded
+}
+
+// the stacked images are jpeg; webp caps a side at 16383 pixels, too short to stack a chapter into
+fn jpeg_size(head: &[u8]) -> Option<(u32, u32)> {
+	fn length(head: &[u8], at: usize) -> Option<usize> {
+		Some(usize::from(u16::from_be_bytes([
+			*head.get(at)?,
+			*head.get(at + 1)?,
+		])))
+	}
+
+	if *head.first()? != 0xFF || *head.get(1)? != 0xD8 {
+		return None;
+	}
+
+	let mut index = 2;
+	while *head.get(index)? == 0xFF {
+		match *head.get(index + 1)? {
+			// padding written ahead of the next marker
+			0xFF => index += 1,
+			// markers standing on their own, without a segment behind them
+			0x01 | 0xD0..=0xD9 => index += 2,
+			// a frame header, which opens with the precision and then the size of the image
+			0xC0..=0xC3 | 0xC5..=0xC7 | 0xC9..=0xCB | 0xCD..=0xCF => {
+				let height = length(head, index + 5)?.try_into().ok()?;
+				let width = length(head, index + 7)?.try_into().ok()?;
+				return Some((width, height));
+			}
+			_ => index += 2 + length(head, index + 2)?,
+		}
+	}
+
+	None
 }

--- a/templates/mangareader/src/imp.rs
+++ b/templates/mangareader/src/imp.rs
@@ -1,19 +1,27 @@
-use super::{Params, helper::ElementImageAttr, parser};
+use super::{
+	Params,
+	helper::{ElementImageAttr, stacked_page_count},
+	parser,
+};
 use aidoku::{
 	Chapter, DeepLinkResult, FilterValue, HomeComponent, HomeComponentValue, HomeLayout,
 	ImageResponse, Listing, Manga, MangaPageResult, MangaWithChapter, Page, PageContent,
 	PageContext, Result,
-	alloc::{String, Vec, borrow::Cow},
+	alloc::{String, Vec, borrow::Cow, string::ToString},
+	canvas::Rect,
 	helpers::uri::{QueryParameters, encode_uri_component},
 	imports::{
-		canvas::ImageRef,
-		error::AidokuError,
+		canvas::{Canvas, ImageRef},
 		html::{Element, Html},
 		net::Request,
 		std::send_partial_result,
 	},
 	prelude::*,
 };
+
+// a chapter that stacks its pages into one image holds a couple of them at most, so a chapter
+// with a page per image never pays for the requests that measure them
+const STACKED_IMAGE_LIMIT: usize = 4;
 
 pub trait Impl {
 	fn new() -> Self;
@@ -147,27 +155,56 @@ pub trait Impl {
 		let html_text = json["html"].as_str().unwrap_or_default();
 		let html = Html::parse_fragment(html_text)?;
 
-		Ok(html
+		let images: Vec<(String, bool)> = html
 			.select(&params.page_selector)
 			.map(|els| {
 				els.filter_map(|el| {
 					let url = el
 						.img_attr()
 						.or_else(|| el.select_first("img").and_then(|img| img.img_attr()))?;
-					Some(Page {
-						content: if el.has_class("shuffled") {
-							let mut context = PageContext::default();
-							context.insert("shuffled".into(), "1".into());
-							PageContent::url_context(url.trim(), context)
-						} else {
-							PageContent::url(url.trim())
-						},
-						..Default::default()
-					})
+					Some((String::from(url.trim()), el.has_class("shuffled")))
 				})
-				.collect::<Vec<_>>()
+				.collect()
 			})
-			.unwrap_or_default())
+			.unwrap_or_default();
+
+		let measure = params.stacked_page_ratio.is_some() && images.len() <= STACKED_IMAGE_LIMIT;
+		let mut pages = Vec::with_capacity(images.len());
+		for (url, shuffled) in images {
+			let slices = match params.stacked_page_ratio {
+				Some(ratio) if measure => stacked_page_count(&url, ratio),
+				_ => 1,
+			};
+
+			if slices < 2 {
+				pages.push(Page {
+					content: if shuffled {
+						let mut context = PageContext::default();
+						context.insert("shuffled".into(), "1".into());
+						PageContent::url_context(url, context)
+					} else {
+						PageContent::url(url)
+					},
+					..Default::default()
+				});
+				continue;
+			}
+
+			for slice in 0..slices {
+				let mut context = PageContext::default();
+				if shuffled {
+					context.insert("shuffled".into(), "1".into());
+				}
+				context.insert("slice".into(), slice.to_string());
+				context.insert("slices".into(), slices.to_string());
+				pages.push(Page {
+					content: PageContent::url_context(url.clone(), context),
+					..Default::default()
+				});
+			}
+		}
+
+		Ok(pages)
 	}
 
 	fn get_manga_list(
@@ -190,7 +227,7 @@ pub trait Impl {
 	}
 
 	fn get_home(&self, params: &Params) -> Result<HomeLayout> {
-		let html = Request::get(format!("{}/home", params.base_url))?.html()?;
+		let html = Request::get(format!("{}{}", params.base_url, params.home_path))?.html()?;
 
 		let mut components = Vec::new();
 
@@ -390,10 +427,37 @@ pub trait Impl {
 	fn process_page_image(
 		&self,
 		_params: &Params,
-		_response: ImageResponse,
-		_context: Option<PageContext>,
+		response: ImageResponse,
+		context: Option<PageContext>,
 	) -> Result<ImageRef> {
-		Err(AidokuError::Unimplemented)
+		let Some(context) = context else {
+			return Ok(response.image);
+		};
+		let number = |key: &str| context.get(key).and_then(|value| value.parse::<u32>().ok());
+		let (Some(slice), Some(slices)) = (number("slice"), number("slices")) else {
+			return Ok(response.image);
+		};
+		if slices < 2 || slice >= slices {
+			return Ok(response.image);
+		}
+
+		let width = response.image.width();
+		let height = response.image.height() as u32;
+		// whole pixel rows: the app's crop rounds a fractional rect, which would draw a row twice
+		// or drop it at the boundary between two slices
+		let top = height * slice / slices;
+		let bottom = height * (slice + 1) / slices;
+		let (top, slice_height) = (top as f32, (bottom - top) as f32);
+
+		// the canvas has to match the slice: app versions before the AidokuRunner fix in e44d774
+		// placed the destination rect off any canvas shorter than the image, drawing nothing
+		let mut canvas = Canvas::new(width, slice_height);
+		canvas.copy_image(
+			&response.image,
+			Rect::new(0.0, top, width, slice_height),
+			Rect::new(0.0, 0.0, width, slice_height),
+		);
+		Ok(canvas.get_image())
 	}
 
 	fn handle_deep_link(&self, params: &Params, url: String) -> Result<Option<DeepLinkResult>> {

--- a/templates/mangareader/src/imp.rs
+++ b/templates/mangareader/src/imp.rs
@@ -19,8 +19,7 @@ use aidoku::{
 	prelude::*,
 };
 
-// a chapter that stacks its pages into one image holds a couple of them at most, so a chapter
-// with a page per image never pays for the requests that measure them
+// a stacked chapter holds a couple of images at most; past this, skip the measuring requests
 const STACKED_IMAGE_LIMIT: usize = 4;
 
 pub trait Impl {
@@ -155,14 +154,14 @@ pub trait Impl {
 		let html_text = json["html"].as_str().unwrap_or_default();
 		let html = Html::parse_fragment(html_text)?;
 
-		let images: Vec<(String, bool)> = html
+		let images: Vec<String> = html
 			.select(&params.page_selector)
 			.map(|els| {
 				els.filter_map(|el| {
 					let url = el
 						.img_attr()
 						.or_else(|| el.select_first("img").and_then(|img| img.img_attr()))?;
-					Some((String::from(url.trim()), el.has_class("shuffled")))
+					Some(String::from(url.trim()))
 				})
 				.collect()
 			})
@@ -170,7 +169,7 @@ pub trait Impl {
 
 		let measure = params.stacked_page_ratio.is_some() && images.len() <= STACKED_IMAGE_LIMIT;
 		let mut pages = Vec::with_capacity(images.len());
-		for (url, shuffled) in images {
+		for url in images {
 			let slices = match params.stacked_page_ratio {
 				Some(ratio) if measure => stacked_page_count(&url, ratio),
 				_ => 1,
@@ -178,13 +177,7 @@ pub trait Impl {
 
 			if slices < 2 {
 				pages.push(Page {
-					content: if shuffled {
-						let mut context = PageContext::default();
-						context.insert("shuffled".into(), "1".into());
-						PageContent::url_context(url, context)
-					} else {
-						PageContent::url(url)
-					},
+					content: PageContent::url(url),
 					..Default::default()
 				});
 				continue;
@@ -192,9 +185,6 @@ pub trait Impl {
 
 			for slice in 0..slices {
 				let mut context = PageContext::default();
-				if shuffled {
-					context.insert("shuffled".into(), "1".into());
-				}
 				context.insert("slice".into(), slice.to_string());
 				context.insert("slices".into(), slices.to_string());
 				pages.push(Page {
@@ -443,14 +433,12 @@ pub trait Impl {
 
 		let width = response.image.width();
 		let height = response.image.height() as u32;
-		// whole pixel rows: the app's crop rounds a fractional rect, which would draw a row twice
-		// or drop it at the boundary between two slices
+		// integer rows: the app rounds a fractional rect, doubling or dropping a row at the seam
 		let top = height * slice / slices;
 		let bottom = height * (slice + 1) / slices;
 		let (top, slice_height) = (top as f32, (bottom - top) as f32);
 
-		// the canvas has to match the slice: app versions before the AidokuRunner fix in e44d774
-		// placed the destination rect off any canvas shorter than the image, drawing nothing
+		// before the AidokuRunner fix in e44d774 a canvas shorter than the image drew nothing
 		let mut canvas = Canvas::new(width, slice_height);
 		canvas.copy_image(
 			&response.image,

--- a/templates/mangareader/src/lib.rs
+++ b/templates/mangareader/src/lib.rs
@@ -34,7 +34,7 @@ pub struct Params {
 	pub get_page_url_path: fn(&str) -> String,
 	pub set_default_filters: fn(&mut QueryParameters) -> (),
 	// some sites stack every page of a chapter into one tall image. set to how many times its
-	// width a page stands to have those measured and handed over a slice at a time
+	// width a page stands to have those sliced apart
 	pub stacked_page_ratio: Option<f32>,
 }
 

--- a/templates/mangareader/src/lib.rs
+++ b/templates/mangareader/src/lib.rs
@@ -9,10 +9,11 @@ use aidoku::{
 	prelude::*,
 };
 
-pub mod helper;
+mod helper;
 mod imp;
 pub mod parser;
 
+pub use helper::slice_count;
 pub use imp::Impl;
 
 pub struct Params {

--- a/templates/mangareader/src/lib.rs
+++ b/templates/mangareader/src/lib.rs
@@ -9,7 +9,7 @@ use aidoku::{
 	prelude::*,
 };
 
-mod helper;
+pub mod helper;
 mod imp;
 pub mod parser;
 
@@ -18,6 +18,8 @@ pub use imp::Impl;
 pub struct Params {
 	pub base_url: Cow<'static, str>,
 	pub search_path: Cow<'static, str>,
+	// path of the page the home layout is read off
+	pub home_path: Cow<'static, str>,
 	pub search_param: Cow<'static, str>,
 	pub page_param: Cow<'static, str>,
 	pub page_selector: Cow<'static, str>,
@@ -25,9 +27,14 @@ pub struct Params {
 	pub get_chapter_selector: fn() -> Cow<'static, str>,
 	// the language of a chapter
 	pub get_chapter_language: fn(&Element) -> String,
+	// some sites only repeat the chapter number in the name, leaving no title to show
+	pub has_chapter_titles: bool,
 	// path added to base url for page list ajax request
 	pub get_page_url_path: fn(&str) -> String,
 	pub set_default_filters: fn(&mut QueryParameters) -> (),
+	// some sites stack every page of a chapter into one tall image. set to how many times its
+	// width a page stands to have those measured and handed over a slice at a time
+	pub stacked_page_ratio: Option<f32>,
 }
 
 impl Default for Params {
@@ -35,13 +42,16 @@ impl Default for Params {
 		Self {
 			base_url: "".into(),
 			search_path: "/search".into(),
+			home_path: "/home".into(),
 			search_param: "keyword".into(),
 			page_param: "page".into(),
 			page_selector: ".container-reader-chapter > div > img".into(),
 			get_chapter_selector: || "#en-chapters > li".into(),
 			get_chapter_language: |_| "en".into(),
+			has_chapter_titles: true,
 			get_page_url_path: |chapter_id| format!("//ajax/image/list/{chapter_id}?mode=vertical"),
 			set_default_filters: |_| {},
+			stacked_page_ratio: None,
 		}
 	}
 }

--- a/templates/mangareader/src/parser.rs
+++ b/templates/mangareader/src/parser.rs
@@ -40,10 +40,12 @@ pub fn parse_manga_details(manga: &mut Manga, html: &Document) -> Result<()> {
 		.select_first("#ani_detail")
 		.ok_or(AidokuError::message("Unable to find manga details"))?;
 
-	manga.title = element
+	if let Some(title) = element
 		.select_first(".manga_name, .manga-name")
 		.and_then(|e| e.own_text())
-		.unwrap_or(manga.title.clone());
+	{
+		manga.title = title;
+	}
 	manga.cover = element.select_first("img").and_then(|img| img.img_attr());
 
 	let (authors, artists) = element

--- a/templates/mangareader/src/parser.rs
+++ b/templates/mangareader/src/parser.rs
@@ -41,7 +41,7 @@ pub fn parse_manga_details(manga: &mut Manga, html: &Document) -> Result<()> {
 		.ok_or(AidokuError::message("Unable to find manga details"))?;
 
 	manga.title = element
-		.select_first(".manga_name")
+		.select_first(".manga_name, .manga-name")
 		.and_then(|e| e.own_text())
 		.unwrap_or(manga.title.clone());
 	manga.cover = element.select_first("img").and_then(|img| img.img_attr());
@@ -142,6 +142,9 @@ pub fn parse_manga_chapters(html: &Document, params: &Params) -> Option<Vec<Chap
 								.parse::<f32>()
 								.ok()
 						});
+				if !params.has_chapter_titles {
+					title = None;
+				}
 				if title.as_ref().is_some_and(|t| {
 					*t == format!("Chapter {}", chapter_number.unwrap_or_default())
 						|| *t == format!("第{}話", chapter_number.unwrap_or_default())


### PR DESCRIPTION
mangamura.me and rawotaku.com serve most chapters as one tall jpeg with every page stacked into
it. The template now reads the size off the header and hands the reader one slice at a time.

A page stands about 1.42 times its width on both sites. The ratio alone rounds 1403x38912 up to
20 pages and cuts every one of them, so the count falls back on the neighbour that divides the
image evenly: 19 leaves a page of exactly 2048. Only chapters of four images or fewer are
measured, so a chapter with a page per image pays for no extra requests.

Three more fixes came out of testing on device.

- The detail title selector is `.manga-name` on both sites, not `.manga_name`, so titles came
  back empty.
- mangamura has no `/home`. The same layout sits at the root, so the path is a param now.
- The chapter name only ever repeats the number, either bare, with a volume suffix
  (`第12.2話-v23`) or wrapped in the seo heading (`約束のネバーランド (Raw – Free) 【第181.6話】`).
  Across 118 chapters from 6 manga none carried a title of its own, so both sources turn chapter
  titles off.

`minAppVersion` is 0.9 because the canvas the slicing draws into needs the AidokuRunner fix in
e44d774.

Verified on device with a local source list.
