### PR TITLE
feat(ja.soraraw): read the rankings from their own json

### DIFF
--- a/sources/ja.soraraw/res/source.json
+++ b/sources/ja.soraraw/res/source.json
@@ -2,7 +2,7 @@
 	"info": {
 		"id": "ja.soraraw",
 		"name": "Soraraw",
-		"version": 3,
+		"version": 4,
 		"url": "https://soraraw.com",
 		"contentRating": 2,
 		"languages": [
@@ -16,12 +16,16 @@
 			"name": "新着"
 		},
 		{
-			"id": "hot",
-			"name": "人気"
+			"id": "rising",
+			"name": "急上昇"
 		},
 		{
 			"id": "trending",
 			"name": "ランキング"
+		},
+		{
+			"id": "lifetime",
+			"name": "殿堂入り"
 		}
 	],
 	"config": {

--- a/sources/ja.soraraw/src/lib.rs
+++ b/sources/ja.soraraw/src/lib.rs
@@ -270,6 +270,18 @@ impl Soraraw {
 			entries: data.results.into_iter().map(Manga::from).collect(),
 		})
 	}
+
+	// a ranking arrives as one json holding every entry, leaving no page for the app to ask for
+	fn parse_top(period: &str) -> Result<MangaPageResult> {
+		let top = Request::get(format!("{BASE_URL}/top/{period}.json"))?.json_owned::<TopList>()?;
+		if top.mangas.is_empty() {
+			bail!("the {period} ranking came back empty");
+		}
+		Ok(MangaPageResult {
+			entries: top.mangas.into_iter().map(Manga::from).collect(),
+			has_next_page: false,
+		})
+	}
 }
 
 impl PageImageProcessor for Soraraw {
@@ -312,23 +324,10 @@ impl PageImageProcessor for Soraraw {
 impl ListingProvider for Soraraw {
 	fn get_manga_list(&self, listing: Listing, page: i32) -> Result<MangaPageResult> {
 		match listing.id.as_str() {
-			// both lists are embedded in the home page as a single batch, with no page to follow
-			"hot" | "trending" => {
-				let props = next_data::<HomeProps>(BASE_URL)?;
-				let entries = if listing.id == "hot" {
-					props.data.hot
-				} else {
-					props
-						.initial_trending
-						.map(|trending| trending.mangas)
-						.unwrap_or_default()
-				};
-
-				Ok(MangaPageResult {
-					entries: entries.into_iter().map(Manga::from).collect(),
-					has_next_page: false,
-				})
-			}
+			"rising" => Self::parse_top("rising"),
+			// the id is kept from before the rankings were split by period
+			"trending" => Self::parse_top("last30Days"),
+			"lifetime" => Self::parse_top("lifetime"),
 			_ => Self::parse_list(&paginated(&format!("{BASE_URL}/newest"), page)),
 		}
 	}

--- a/sources/ja.soraraw/src/models.rs
+++ b/sources/ja.soraraw/src/models.rs
@@ -29,26 +29,16 @@ pub struct DataProps<T> {
 	pub data: T,
 }
 
-// "/" is the only page holding both the popular and the trending lists
+// "/top/{period}.json", the ranking lists the site fetches from the browser
 #[derive(Deserialize)]
-pub struct HomeProps {
-	pub data: ListData,
-	#[serde(rename = "initialTrending")]
-	pub initial_trending: Option<Trending>,
-}
-
-#[derive(Deserialize)]
-pub struct Trending {
+pub struct TopList {
 	#[serde(default)]
 	pub mangas: Vec<MangaEntry>,
 }
 
-// "/", "/newest" and "/genre/{slug}"
+// "/newest" and "/genre/{slug}"
 #[derive(Deserialize)]
 pub struct ListData {
-	// only filled in on the home page
-	#[serde(default)]
-	pub hot: Vec<MangaEntry>,
 	#[serde(default)]
 	pub results: Vec<MangaEntry>,
 	pub pagination: Option<Pagination>,

--- a/sources/ja.soraraw/src/test.rs
+++ b/sources/ja.soraraw/src/test.rs
@@ -61,7 +61,7 @@ fn page_slices(pages: &[Page]) -> Vec<(&String, &String, &String)> {
 
 #[aidoku_test]
 fn test_listings() {
-	for id in ["newest", "hot", "trending"] {
+	for id in ["newest", "rising", "trending", "lifetime"] {
 		let result = Soraraw.get_manga_list(listing(id), 1).expect("listing");
 		assert!(!result.entries.is_empty(), "{id} returned no entries");
 
@@ -85,7 +85,7 @@ fn test_listings() {
 	}
 }
 
-// only the paginated listing walks pages; the other two hand out a single batch
+// only the paginated listing walks pages; the rankings hand out a single batch
 #[aidoku_test]
 fn test_listing_pagination() {
 	let first = Soraraw
@@ -99,8 +99,16 @@ fn test_listing_pagination() {
 	assert!(!second.entries.is_empty());
 	assert_ne!(first.entries[0].key, second.entries[0].key);
 
-	let hot = Soraraw.get_manga_list(listing("hot"), 1).expect("hot");
-	assert!(!hot.has_next_page);
+	// the rankings were read off the home page before, which embeds ten of them at most
+	for id in ["rising", "trending", "lifetime"] {
+		let result = Soraraw.get_manga_list(listing(id), 1).expect(id);
+		assert!(!result.has_next_page);
+		assert!(
+			result.entries.len() > 100,
+			"{id} returned {} entries",
+			result.entries.len()
+		);
+	}
 }
 
 // the series below is looked up by its japanese title and by its romanised alternative one,


### PR DESCRIPTION
The listings only read what the home page embeds, so "trending" handed out ten entries and
"hot" twenty. The site keeps its rankings in /top/{period}.json, which hold two hundred each.

The listings are now 新着 (newest), 急上昇 (rising), ランキング (last30Days) and 殿堂入り
(lifetime).

"hot" is dropped. Every one of its twenty entries carries is_pin, and the site has no more of
them, so it is a pinned selection rather than a ranking.
