### PR TITLE
feat(ja.spoilerplus): expose the site tabs as listings

### DIFF
--- a/sources/ja.spoilerplus/res/filters.json
+++ b/sources/ja.spoilerplus/res/filters.json
@@ -1,8 +1,0 @@
-[
-	{
-		"type": "sort",
-		"id": "sort",
-		"canAscend": false,
-		"options": ["最近の更新", "ランキング"]
-	}
-]

--- a/sources/ja.spoilerplus/res/source.json
+++ b/sources/ja.spoilerplus/res/source.json
@@ -2,13 +2,24 @@
 	"info": {
 		"id": "ja.spoilerplus",
 		"name": "SpoilerPlus",
-		"version": 1,
+		"version": 2,
 		"url": "https://spoilerplus.tv",
 		"contentRating": 2,
 		"languages": ["ja"],
 		"minAppVersion": "0.7.1"
 	},
-	"config": {
-		"hidesFiltersWhileSearching": true
-	}
+	"listings": [
+		{
+			"id": "latest",
+			"name": "最近の更新"
+		},
+		{
+			"id": "trending",
+			"name": "トレンド"
+		},
+		{
+			"id": "ranking",
+			"name": "ランキング"
+		}
+	]
 }

--- a/sources/ja.spoilerplus/src/helpers.rs
+++ b/sources/ja.spoilerplus/src/helpers.rs
@@ -1,5 +1,4 @@
 use aidoku::{
-	FilterValue,
 	alloc::string::String,
 	helpers::uri::{decode_uri, encode_uri},
 	prelude::format,
@@ -34,16 +33,6 @@ pub fn to_key(href: &str) -> Option<String> {
 // raw utf-8 paths are answered with a 404, so keys are encoded on the way out
 pub fn url_for(key: &str) -> String {
 	format!("{BASE_URL}{}", encode_uri(key))
-}
-
-pub fn sort_index(filters: &[FilterValue]) -> i32 {
-	filters
-		.iter()
-		.find_map(|filter| match filter {
-			FilterValue::Sort { index, .. } => Some(*index),
-			_ => None,
-		})
-		.unwrap_or(0)
 }
 
 pub fn read_window_number(data: &str, name: &str, fractional: bool) -> Option<String> {

--- a/sources/ja.spoilerplus/src/lib.rs
+++ b/sources/ja.spoilerplus/src/lib.rs
@@ -76,18 +76,20 @@ impl Impl for SpoilerPlus {
 			manga_page: |_, manga| url_for(&manga.key),
 			page_list_page: |_, _, chapter| url_for(&chapter.key),
 
-			get_search_url: |params, query, page, filters| {
-				// search has its own endpoint, so a query wins over the sort filter
-				if let Some(query) = query {
-					let query = encode_uri_component(query);
-					return Ok(format!("{}?s={query}&page={page}", params.base_url));
-				}
+			get_search_url: |params, query, page, _| {
+				let Some(query) = query else {
+					return Ok(format!("{}/page/{page}/", params.base_url));
+				};
+				let query = encode_uri_component(query);
+				Ok(format!("{}?s={query}&page={page}", params.base_url))
+			},
 
-				// no sort parameter: each ordering is served from its own path
-				Ok(match sort_index(&filters) {
-					1 => format!("{}/ranking/{page}/", params.base_url),
-					_ => format!("{}/page/{page}/", params.base_url),
-				})
+			get_listing_url: |params, listing, page| match listing.id.as_str() {
+				"latest" => Ok(format!("{}/page/{page}/", params.base_url)),
+				// trending has no pager and serves the same block for every page
+				"trending" => Ok(format!("{}/trending/", params.base_url)),
+				"ranking" => Ok(format!("{}/ranking/{page}/", params.base_url)),
+				id => Err(error!("Unknown listing {id}")),
 			},
 
 			..Default::default()
@@ -296,6 +298,7 @@ impl Impl for SpoilerPlus {
 
 register_source!(
 	WpComics<SpoilerPlus>,
+	ListingProvider,
 	PageImageProcessor,
 	ImageRequestProvider,
 	DeepLinkHandler

--- a/sources/ja.spoilerplus/src/test.rs
+++ b/sources/ja.spoilerplus/src/test.rs
@@ -1,9 +1,6 @@
 use super::*;
-use aidoku::{DeepLinkHandler, FilterValue, MangaPageResult, alloc::vec};
+use aidoku::{DeepLinkHandler, Listing, ListingProvider, MangaPageResult};
 use aidoku_test::aidoku_test;
-
-const SORT_UPDATED: i32 = 0;
-const SORT_RANKING: i32 = 1;
 
 const SERIES_KEY: &str = "/HUNTER X HUNTER-raw-free/";
 
@@ -11,18 +8,16 @@ fn source() -> WpComics<SpoilerPlus> {
 	WpComics::new()
 }
 
-fn sort(index: i32) -> Vec<FilterValue> {
-	vec![FilterValue::Sort {
-		id: String::from("sort"),
-		index,
-		ascending: false,
-	}]
-}
-
-fn browse(index: i32, page: i32) -> MangaPageResult {
+fn listing(id: &str, page: i32) -> MangaPageResult {
 	source()
-		.get_search_manga_list(None, page, sort(index))
-		.expect("browse request should succeed")
+		.get_manga_list(
+			Listing {
+				id: id.into(),
+				..Default::default()
+			},
+			page,
+		)
+		.expect("listing request should succeed")
 }
 
 fn series() -> Manga {
@@ -47,39 +42,59 @@ fn leading_keys(result: &MangaPageResult) -> Vec<&String> {
 		.collect()
 }
 
-// the app sends no filter value until one is picked
 #[aidoku_test]
-fn test_sort_index_falls_back_to_the_first_option() {
-	assert_eq!(sort_index(&[]), SORT_UPDATED);
-	assert_eq!(sort_index(&sort(SORT_RANKING)), SORT_RANKING);
-}
-
-#[aidoku_test]
-fn test_sort_updated() {
+fn test_listing_latest() {
 	assert!(
-		!browse(SORT_UPDATED, 1).entries.is_empty(),
-		"updates ordering should return entries"
+		!listing("latest", 1).entries.is_empty(),
+		"latest listing should return entries"
 	);
 }
 
 #[aidoku_test]
-fn test_sort_updated_page_2() {
+fn test_listing_latest_page_2() {
 	assert!(
-		!browse(SORT_UPDATED, 2).entries.is_empty(),
-		"updates ordering page 2 should return entries"
+		!listing("latest", 2).entries.is_empty(),
+		"latest listing page 2 should return entries"
 	);
 }
 
 #[aidoku_test]
-fn test_sort_ranking() {
+fn test_listing_ranking() {
 	assert!(
-		!browse(SORT_RANKING, 1).entries.is_empty(),
-		"ranking ordering should return entries"
+		!listing("ranking", 1).entries.is_empty(),
+		"ranking listing should return entries"
+	);
+}
+
+// the trending page has no pager, so the app must not be told to ask for more
+#[aidoku_test]
+fn test_listing_trending_is_a_single_page() {
+	let result = listing("trending", 1);
+	assert!(
+		!result.entries.is_empty(),
+		"trending listing should return entries"
+	);
+	assert!(!result.has_next_page, "trending should not paginate");
+}
+
+#[aidoku_test]
+fn test_unknown_listing_errors() {
+	assert!(
+		source()
+			.get_manga_list(
+				Listing {
+					id: "nope".into(),
+					..Default::default()
+				},
+				1
+			)
+			.is_err(),
+		"an unknown listing should not fall back to another path"
 	);
 }
 
 #[aidoku_test]
-fn test_browse_without_filters() {
+fn test_browse_without_query() {
 	let result = source()
 		.get_search_manga_list(None, 1, Vec::new())
 		.expect("browse request should succeed");
@@ -94,25 +109,11 @@ fn test_search() {
 	assert!(!result.entries.is_empty(), "search should return entries");
 }
 
-#[aidoku_test]
-fn test_query_takes_precedence_over_sort() {
-	let searched = source()
-		.get_search_manga_list(Some(String::from("ワンピース")), 1, sort(SORT_RANKING))
-		.expect("search request should succeed");
-	let ranking = browse(SORT_RANKING, 1);
-	assert!(!searched.entries.is_empty(), "search should return entries");
-	assert_ne!(
-		leading_keys(&searched),
-		leading_keys(&ranking),
-		"a query should search rather than fall back to the ranking path"
-	);
-}
-
-// the updates ordering starts at the home page, which stacks a carousel and a
+// the latest listing starts at the home page, which stacks a carousel and a
 // ranking block around the paginated list
 #[aidoku_test]
-fn test_updated_page_1_holds_only_the_paginated_block() {
-	let result = browse(SORT_UPDATED, 1);
+fn test_latest_page_1_holds_only_the_paginated_block() {
+	let result = listing("latest", 1);
 
 	let mut keys = result
 		.entries
@@ -133,7 +134,7 @@ fn test_updated_page_1_holds_only_the_paginated_block() {
 
 #[aidoku_test]
 fn test_keys_stay_relative_and_covers_absolute() {
-	let result = browse(SORT_UPDATED, 1);
+	let result = listing("latest", 1);
 
 	for manga in &result.entries {
 		assert!(
@@ -151,7 +152,7 @@ fn test_keys_stay_relative_and_covers_absolute() {
 
 #[aidoku_test]
 fn test_pagination_ends() {
-	let result = browse(SORT_UPDATED, 9999);
+	let result = listing("latest", 9999);
 	assert!(
 		result.entries.is_empty() && !result.has_next_page,
 		"out of range page should end pagination"
@@ -159,13 +160,19 @@ fn test_pagination_ends() {
 }
 
 #[aidoku_test]
-fn test_sorts_return_different_orders() {
-	let updated = browse(SORT_UPDATED, 1);
-	let ranking = browse(SORT_RANKING, 1);
+fn test_listings_return_different_orders() {
+	let latest = listing("latest", 1);
+	let trending = listing("trending", 1);
+	let ranking = listing("ranking", 1);
 	assert_ne!(
-		leading_keys(&updated),
+		leading_keys(&latest),
 		leading_keys(&ranking),
-		"the sort options should not resolve to the same order"
+		"latest and ranking should not resolve to the same order"
+	);
+	assert_ne!(
+		leading_keys(&trending),
+		leading_keys(&ranking),
+		"trending and ranking should not resolve to the same order"
 	);
 }
 

--- a/templates/wpcomics/src/lib.rs
+++ b/templates/wpcomics/src/lib.rs
@@ -1,8 +1,9 @@
 #![no_std]
 use aidoku::{
 	AidokuError, Chapter, ContentRating, DeepLinkHandler, DeepLinkResult, DynamicFilters, Filter,
-	FilterValue, Home, HomeLayout, ImageRequestProvider, ImageResponse, ListingProvider, Manga,
-	MangaPageResult, MangaStatus, Page, PageContext, PageImageProcessor, Result, Source, Viewer,
+	FilterValue, Home, HomeLayout, ImageRequestProvider, ImageResponse, Listing, ListingProvider,
+	Manga, MangaPageResult, MangaStatus, Page, PageContext, PageImageProcessor, Result, Source,
+	Viewer,
 	alloc::{String, Vec, borrow::Cow},
 	imports::{canvas::ImageRef, html::Element, net::Request},
 	prelude::*,
@@ -77,6 +78,7 @@ pub struct Params {
 		page: i32,
 		filters: Vec<FilterValue>,
 	) -> Result<String>,
+	pub get_listing_url: fn(params: &Params, listing: &Listing, page: i32) -> Result<String>,
 
 	pub home_manga_link: &'static str,
 	pub home_chapter_link: &'static str,
@@ -217,6 +219,7 @@ impl Default for Params {
 			get_search_url: |params, query, page, filters| {
 				get_search_url(params, query, page, filters)
 			},
+			get_listing_url: |_, _, _| Err(AidokuError::Unimplemented),
 
 			home_manga_link: ".book_info a",
 			home_chapter_link: ".last_chapter a, .chapter-item a",
@@ -298,8 +301,10 @@ impl<T: Impl> Source for WpComics<T> {
 }
 
 impl<T: Impl> ListingProvider for WpComics<T> {
-	fn get_manga_list(&self, _listing: aidoku::Listing, _page: i32) -> Result<MangaPageResult> {
-		Err(AidokuError::Unimplemented)
+	fn get_manga_list(&self, listing: Listing, page: i32) -> Result<MangaPageResult> {
+		let url = (self.params.get_listing_url)(&self.params, &listing, page)?;
+		let mut cache = self.cache.borrow_mut();
+		self.inner.get_manga_list(&mut cache, &self.params, url)
 	}
 }
 


### PR DESCRIPTION
The site serves its browse tabs from separate paths, so they fit listings better than a sort filter.

- `latest`, `trending` and `ranking` replace the sort filter, which only carried two of the three.
- `trending` has no pager, so that listing stays a single page.
- The wpcomics template gains `get_listing_url`. Sources that leave it unset keep returning `Unimplemented`.
